### PR TITLE
update system-tests to test again MongoDB 7

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,10 +51,10 @@
         <vertx-proton.version>3.8.3</vertx-proton.version>
         <qpid-jms-client.version>1.0.0</qpid-jms-client.version>
         <jsonassert.version>1.5.0</jsonassert.version>
-        <mongo-java-driver.version>4.1.2</mongo-java-driver.version>
+        <mongo-java-driver.version>4.11.1</mongo-java-driver.version>
 
         <scala.version>2.13</scala.version>
-        <scala.version.full>2.13.10</scala.version.full>
+        <scala.version.full>2.13.12</scala.version.full>
 
         <gatling.version>3.6.1</gatling.version>
         <pekko.version>1.0.1</pekko.version>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - PORT=9900
 
   mongodb:
-    image: docker.io/mongo:5.0
+    image: docker.io/mongo:7.0
     networks:
       - test
     expose:


### PR DESCRIPTION
@alstanchev @kalinkostashki it would be great if you could run the System-Tests with MongoDB 7 to verify Ditto works with that (it should, all the used drivers support also MongoDB 7).