### PR TITLE
Acceptance tests against a deployed Ditto, BasicAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ cd docker
 
 # OAuth mock server
 docker-compose up -d oauth
-``
+```

--- a/README.md
+++ b/README.md
@@ -66,3 +66,44 @@ cd docker
 # OAuth mock server
 docker-compose up -d oauth
 ```
+
+# Acceptance tests
+A subset of the system tests, called `Acceptance tests`, could be run against remote Ditto deployment.
+These need some environment variables set before execution, depending on authentication method configured in Ditto deployment.
+The following variables must be set:
+
+   * for BasicAuth:
+```
+      BASIC_AUTH_ENABLED = true     # boolean to configure tests
+      DEFAULT_HOSTNAME              # the hostname of the Ditto deployment
+      BASIC_AUTH_USERNAME           # Ditto username for basic auth
+      BASIC_AUTH_PASSWORD           # the password for the user
+```
+  * for OAuth - the tests need an OAuth provider and 4 separate OAuth clients:
+```
+      BASIC_AUTH_ENABLED = false  # default value, could be skipped
+      DEFAULT_HOSTNAME            # the hostname of the Ditto deployment
+
+      OAUTH_TOKEN_ENDPOINT        # OAuth token endpoint for getting tokens
+      OAUTH_ISSUER                # should match the value configured in Ditto
+
+      OAUTH_CLIENT_ID             # main client id
+      OAUTH_CLIENT_SECRET         # main client secret
+      OAUTH_CLIENT_SCOPE          # main client scope
+
+      OAUTH_CLIENT2_ID            # 2nd client id
+      OAUTH_CLIENT2_SECRET        # 2nd client secret
+      OAUTH_CLIENT2_SCOPE         # 2nd client scope
+
+      OAUTH_CLIENT3_ID            # 3rd client id
+      OAUTH_CLIENT3_SECRET        # 3rd client secret
+      OAUTH_CLIENT3_SCOPE         # 3rd client scope
+
+      OAUTH_CLIENT4_ID            # 4th client id
+      OAUTH_CLIENT4_SECRET        # 4th client secret
+      OAUTH_CLIENT4_SCOPE         # 4th client scope
+```
+Run maven with profile `acceptance` and set property `test.environment=deployment`, e.g. with the following command:
+```
+mvn verify -am -amd --projects=system -Pacceptance -Dtest.environment=deployment -Dtest.timeoutMs=240000 -Dskip.categories=ServiceBus
+```

--- a/common/src/main/java/org/eclipse/ditto/testing/common/CommonTestConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/CommonTestConfig.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.testing.common;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.ditto.policies.model.PoliciesModelFactory.newSubjectIssuer;
 
 import java.time.Duration;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
 import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +73,15 @@ public class CommonTestConfig {
 
     private static final String OAUTH_MOCK_PREFIX = "oauth-mock.";
     private static final String OAUTH_MOCK_TOKEN_ENDPOINT = OAUTH_MOCK_PREFIX + "tokenEndpoint";
+    private static final String OAUTH_PREFIX = "oauth.";
+    private static final String OAUTH_TOKEN_ENDPOINT = OAUTH_PREFIX + "tokenEndpoint";
+    private static final String OAUTH_ISSUER = OAUTH_PREFIX + "issuer";
+    private static final String OAUTH_CLIENT_IDS[]
+            = { OAUTH_PREFIX + "clientId", OAUTH_PREFIX + "client2Id", OAUTH_PREFIX + "client3Id", OAUTH_PREFIX + "client4Id" };
+    private static final String OAUTH_CLIENT_SECRETS[]
+            = { OAUTH_PREFIX + "clientSecret", OAUTH_PREFIX + "client2Secret", OAUTH_PREFIX + "client3Secret", OAUTH_PREFIX + "client4Secret" };
+    private static final String OAUTH_CLIENT_SCOPES[]
+            = { OAUTH_PREFIX + "clientScope", OAUTH_PREFIX + "client2Scope", OAUTH_PREFIX + "client3Scope", OAUTH_PREFIX + "client4Scope" };
 
     private static final String PROPERTY_TEST_ENVIRONMENT = "test.environment";
     private static final String TEST_ENVIRONMENT_LOCAL = "local";
@@ -302,6 +313,31 @@ public class CommonTestConfig {
         return baseUrl + subUrl;
     }
 
-    public String getOAuthMockTokenEndpoint() { return conf.getString(OAUTH_MOCK_TOKEN_ENDPOINT); }
+    public String getOAuthMockTokenEndpoint() {
+        return conf.getString(OAUTH_MOCK_TOKEN_ENDPOINT);
+    }
+
+    public String getOAuthTokenEndpoint() {
+        return conf.getString(OAUTH_TOKEN_ENDPOINT);
+    }
+
+    public SubjectIssuer getOAuthIssuer() {
+        return newSubjectIssuer(conf.getString(OAUTH_ISSUER));
+    }
+
+    public String getOAuthClientId(final int n) {
+        if (n > OAUTH_CLIENT_IDS.length) return "invalidClientId";
+        return conf.getString(OAUTH_CLIENT_IDS[n - 1]);
+    }
+
+    public String getOAuthClientSecret(final int n) {
+        if (n > OAUTH_CLIENT_SECRETS.length) return "invalidClientSecret";
+        return conf.getString(OAUTH_CLIENT_SECRETS[n - 1]);
+    }
+
+    public String getOAuthClientScope(final int n) {
+        if (n > OAUTH_CLIENT_SCOPES.length) return "invalidClientScope";
+        return conf.getString(OAUTH_CLIENT_SCOPES[n - 1]);
+    }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/CommonTestConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/CommonTestConfig.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,9 @@ public class CommonTestConfig {
 
     private static final String PROPERTY_GATEWAY_URL = GATEWAY_PREFIX + "url";
     private static final String PROPERTY_GATEWAY_WS_URL = GATEWAY_PREFIX + "ws-url";
+    private static final String PROPERTY_GATEWAY_BASIC_AUTH_ENABLED = GATEWAY_PREFIX + "basic-auth.enabled";
+    private static final String PROPERTY_GATEWAY_BASIC_AUTH_PASSWORD = GATEWAY_PREFIX + "basic-auth.password";
+    private static final String PROPERTY_GATEWAY_BASIC_AUTH_USERNAME = GATEWAY_PREFIX + "basic-auth.username";
     private static final String CONNECTIVITY_PREFIX = "connectivity.";
     private static final String RABBITMQ_PREFIX = CONNECTIVITY_PREFIX + "rabbitmq.";
     private static final String PROPERTY_RABBITMQ_HOSTNAME = RABBITMQ_PREFIX + PROPERTY_LEAF_HOSTNAME;
@@ -257,6 +261,29 @@ public class CommonTestConfig {
 
     private String getWsBaseUrl() {
         return conf.getString(PROPERTY_GATEWAY_WS_URL);
+    }
+
+    public BasicAuth getBasicAuth() {
+        return BasicAuth.newInstance(
+                getBooleanOrDefault(PROPERTY_GATEWAY_BASIC_AUTH_ENABLED, false),
+                getStringOrDefault(PROPERTY_GATEWAY_BASIC_AUTH_USERNAME, ""),
+                getStringOrDefault(PROPERTY_GATEWAY_BASIC_AUTH_PASSWORD, ""));
+    }
+
+    private boolean getBooleanOrDefault(final String path, final boolean defaultValue) {
+        if (conf.hasPath(path)) {
+            return conf.getBoolean(path);
+        } else {
+            return defaultValue;
+        }
+    }
+
+    private String getStringOrDefault(final String path, final String defaultValue) {
+        if (conf.hasPath(path)) {
+            return conf.getString(path);
+        } else {
+            return defaultValue;
+        }
     }
 
     private String getDevopsBaseUrl() {

--- a/common/src/main/java/org/eclipse/ditto/testing/common/IntegrationTest.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/IntegrationTest.java
@@ -648,9 +648,18 @@ public abstract class IntegrationTest {
             if (null == location) {
                 return;
             }
+
             final String thingId = parseIdFromLocation(location);
             rememberForCleanUp(deleteThing(version, thingId));
-            rememberForCleanUpLast(deletePolicy(thingId));
+            String policyId;
+            try {
+                policyId =
+                        JsonObject.of(response.getBody().asByteArray()).getValue("policyId").get().asString();
+            } catch (final Exception ex) {
+                LOGGER.warn("Could not parse policyId of Thing {} to remember for cleanup: {}", thingId, ex.getMessage());
+                policyId = thingId;
+            }
+            rememberForCleanUpLast(deletePolicy(policyId));
         });
         return result;
     }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/IntegrationTest.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/IntegrationTest.java
@@ -336,28 +336,28 @@ public abstract class IntegrationTest {
     /**
      * Creates a new {@link ThingsWebsocketClient}.
      *
-     * @param jwt the token to use for authentication.
+     * @param testingContext the testing context to be used for authentication.
      * @param additionalHttpHeaders additional HTTP headers to set for the initial WS request.
      * @param apiVersion the API version to use for opening the WS.
      * @return the created ThingsWebsocketClient instance.
      */
-    protected static ThingsWebsocketClient newTestWebsocketClient(final String jwt,
+    protected static ThingsWebsocketClient newTestWebsocketClient(final TestingContext testingContext,
             final Map<String, String> additionalHttpHeaders, final int apiVersion) {
 
-        return newTestWebsocketClient(jwt, additionalHttpHeaders, apiVersion,
+        return newTestWebsocketClient(testingContext, additionalHttpHeaders, apiVersion,
                     ThingsWebsocketClient.AuthMethod.HEADER);
     }
 
     /**
      * Creates a new {@link ThingsWebsocketClient}.
      *
-     * @param jwt the token to use for authentication.
+     * @param testingContext the testing context to be used for authentication.
      * @param additionalHttpHeaders additional HTTP headers to set for the initial WS request.
      * @param apiVersion the API version to use for opening the WS.
-     * @param authMethod the jwt auth method used.
+     * @param authMethod the testingContext auth method used.
      * @return the created ThingsWebsocketClient instance.
      */
-    protected static ThingsWebsocketClient newTestWebsocketClient(final String jwt,
+    protected static ThingsWebsocketClient newTestWebsocketClient(final TestingContext testingContext,
             final Map<String, String> additionalHttpHeaders, final int apiVersion, final
     ThingsWebsocketClient.AuthMethod authMethod) {
 
@@ -369,8 +369,7 @@ public abstract class IntegrationTest {
             proxyServer = null;
         }
 
-        return ThingsWebsocketClient.newInstance(dittoWsUrl(apiVersion), jwt,
-                serviceEnv.getDefaultTestingContext().getBasicAuth(),
+        return ThingsWebsocketClient.newInstance(dittoWsUrl(apiVersion), testingContext,
                 additionalHttpHeaders, proxyServer,
                 authMethod);
     }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ServiceEnvironment.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ServiceEnvironment.java
@@ -16,11 +16,15 @@ import static java.util.Objects.requireNonNull;
 import static org.eclipse.ditto.testing.common.IntegrationTest.TEST_CONFIG;
 
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.testing.common.client.http.AsyncHttpClientFactory;
+import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
 import org.eclipse.ditto.testing.common.matcher.PostMatcher;
+import org.eclipse.ditto.testing.common.util.LazySupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,34 +34,45 @@ import org.slf4j.LoggerFactory;
 public final class ServiceEnvironment {
 
     public static final String DEFAULT_NAMESPACE = "namespace.default";
-    public static final TestingContext TESTING_CONTEXT = TestingContext.withGeneratedMockClient(
-            new Solution("ditto", "ditto", DEFAULT_NAMESPACE), TEST_CONFIG);
+    public static final String NAMESPACE_TWO = "namespace.two";
+    public static final String NAMESPACE_THREE = "namespace.three";
+    public static final String NAMESPACE_FOUR = "namespace.four";
+    public static final String NAMESPACE_FIVE = "namespace.five";
+
+    private static final Solution TESTING_SOLUTIONS[] = {
+            new Solution("user", "password", DEFAULT_NAMESPACE),
+            new Solution("user2", "password2", NAMESPACE_TWO),
+            new Solution("user3", "password3", NAMESPACE_THREE),
+            new Solution("user4", "password4", NAMESPACE_FOUR),
+            new Solution("user5", "password5", NAMESPACE_FIVE)
+    };
+    private static final TestingContext TESTING_CONTEXT = TestingContext.withGeneratedMockClient(
+            new Solution("user", "password", DEFAULT_NAMESPACE), TEST_CONFIG);
 
     /**
-     * Prefix for the Default namespace of the default solution.
+     * Prefix for the Default namespace of the default Solution.
      */
     private static final String DEFAULT_NAMESPACE_PREFIX = DEFAULT_NAMESPACE + ".";
 
+    private final Supplier<TestingContext> defaultTestingContext;
+    private final Supplier<TestingContext> testingContext2;
+    private final Supplier<TestingContext> testingContext3;
+    private final Supplier<TestingContext> testingContext4;
+    private final Supplier<TestingContext> testingContext5;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceEnvironment.class);
-    public static final String NAMESPACE_TWO = "namespace.two";
-    public static final TestingContext TESTING_CONTEXT2 = TestingContext.withGeneratedMockClient(
-            new Solution("user2", "password2", NAMESPACE_TWO), TEST_CONFIG);
-    public static final String NAMESPACE_THREE = "namespace.three";
-    public static final TestingContext TESTING_CONTEXT3 = TestingContext.withGeneratedMockClient(
-            new Solution("user3", "password3", NAMESPACE_THREE), TEST_CONFIG);
-    public static final String NAMESPACE_FOUR = "namespace.four";
-    public static final TestingContext TESTING_CONTEXT4 = TestingContext.withGeneratedMockClient(
-            new Solution("user4", "password4", NAMESPACE_FOUR), TEST_CONFIG);
-    public static final String NAMESPACE_FIVE = "namespace.five";
-    public static final TestingContext TESTING_CONTEXT5 = TestingContext.withGeneratedMockClient(
-            new Solution("user5", "password5", NAMESPACE_FIVE), TEST_CONFIG);
 
+    private ServiceEnvironment(final Supplier<TestingContext> defaultTestingContext,
+            final Supplier<TestingContext> testingContext2,
+            final Supplier<TestingContext> testingContext3,
+            final Supplier<TestingContext> testingContext4,
+            final Supplier<TestingContext> testingContext5) {
 
-    private final CommonTestConfig testConfig;
-
-    private ServiceEnvironment(final CommonTestConfig testConfig) {
-
-        this.testConfig = requireNonNull(testConfig);
+        this.defaultTestingContext = requireNonNull(defaultTestingContext);
+        this.testingContext2 = requireNonNull(testingContext2);
+        this.testingContext3 = requireNonNull(testingContext3);
+        this.testingContext4 = requireNonNull(testingContext4);
+        this.testingContext5 = requireNonNull(testingContext5);
     }
 
     /**
@@ -69,7 +84,15 @@ public final class ServiceEnvironment {
     public static ServiceEnvironment from(final CommonTestConfig testConfig) {
         requireNonNull(testConfig);
         LOGGER.info("Instantiate ServiceEnvironment");
-        return new ServiceEnvironment(testConfig);
+
+        final Supplier<TestingContext> defaultTestingContext = getTestingContextSupplier(testConfig, 1);
+        final Supplier<TestingContext> testingContext2 = getTestingContextSupplier(testConfig, 2);
+        final Supplier<TestingContext> testingContext3 = getTestingContextSupplier(testConfig, 3);
+        final Supplier<TestingContext> testingContext4 = getTestingContextSupplier(testConfig, 4);
+
+        final Supplier<TestingContext> testingContext5 = getTestingContextSupplier(testConfig, 3);
+
+        return new ServiceEnvironment(defaultTestingContext, testingContext2, testingContext3, testingContext4, testingContext5);
     }
 
     public String getDefaultNamespaceName() {
@@ -82,7 +105,7 @@ public final class ServiceEnvironment {
 
     /**
      * Creates a new instance from the given {@code testConfig} for performance tests. In this case, the default
-     * solution should be reused accross JVM restarts: i.e. it must have a default namespace with fixed (i.e.
+     * TestingContext should be reused accross JVM restarts: i.e. it must have a default namespace with fixed (i.e.
      * non-random) name (needed for perf-tests) and a static secret.
      *
      * @param testConfig the test configuration
@@ -91,10 +114,6 @@ public final class ServiceEnvironment {
     public static ServiceEnvironment forPerformanceTests(final CommonTestConfig testConfig) {
         requireNonNull(testConfig);
         return forPerformanceTests(testConfig);
-    }
-
-    public TestingContext getDefaultTestingContext() {
-        return TESTING_CONTEXT;
     }
 
     public Solution createSolution(final CharSequence namespace) {
@@ -114,8 +133,12 @@ public final class ServiceEnvironment {
         return RandomStringUtils.randomAlphabetic(1) + RandomStringUtils.randomAlphanumeric(10);
     }
 
+    public TestingContext getDefaultTestingContext() {
+        return this.defaultTestingContext.get();
+    }
+
     public TestingContext getTestingContext2() {
-        return TESTING_CONTEXT2;
+        return this.testingContext2.get();
     }
 
     public String getTesting2NamespaceName() {
@@ -123,15 +146,15 @@ public final class ServiceEnvironment {
     }
 
     public TestingContext getTestingContext3() {
-        return TESTING_CONTEXT3;
+        return this.testingContext3.get();
     }
 
     public TestingContext getTestingContext4() {
-        return TESTING_CONTEXT4;
+        return this.testingContext4.get();
     }
 
     public TestingContext getTestingContext5() {
-        return TESTING_CONTEXT5;
+        return this.testingContext5.get();
     }
 
     public String getDefaultAuthUsername() {
@@ -145,9 +168,8 @@ public final class ServiceEnvironment {
 
     private static String createRandomNamespace(final String namespacePrefix) {
         requireNonNull(namespacePrefix);
-        return namespacePrefix + RandomStringUtils.randomAlphabetic(1) + RandomStringUtils.randomAlphanumeric(10);
+        return namespacePrefix + randomString();
     }
-
 
     public PostMatcher postPiggy(final String piggyBackSubUrl, final JsonObject jsonPiggyCommand,
             final String targetActorSelection) {
@@ -155,6 +177,27 @@ public final class ServiceEnvironment {
         return PiggyBackCommander.getInstance(piggyBackSubUrl).preparePost(jsonPiggyCommand, targetActorSelection)
                 .withExpectedStatus(HttpStatus.OK).build();
 
+    }
+
+    private static Supplier<TestingContext> getTestingContextSupplier(
+            final CommonTestConfig config, final int clientNumber) {
+        return LazySupplier.fromLoader(() -> {
+            final TestingContext testingContext;
+            if (config.isLocalOrDockerTestEnvironment() || config.getBasicAuth().isEnabled()) {
+                testingContext = TestingContext.withGeneratedMockClient(TESTING_SOLUTIONS[clientNumber], config);
+            } else {
+                final AuthClient client = AuthClient.newInstance(config.getOAuthTokenEndpoint(),
+                        config.getOAuthIssuer(),
+                        config.getOAuthClientId(clientNumber),
+                        config.getOAuthClientSecret(clientNumber),
+                        config.getOAuthClientScope(clientNumber),
+                        AsyncHttpClientFactory.newInstance(config),
+                        config.getOAuthClientScope(clientNumber),
+                        '@' + config.getOAuthClientId(clientNumber));
+                testingContext = TestingContext.newInstance(TESTING_SOLUTIONS[clientNumber], client, config.getBasicAuth());
+            }
+            return testingContext;
+        });
     }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ServiceEnvironment.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ServiceEnvironment.java
@@ -31,7 +31,7 @@ public final class ServiceEnvironment {
 
     public static final String DEFAULT_NAMESPACE = "namespace.default";
     public static final TestingContext TESTING_CONTEXT = TestingContext.withGeneratedMockClient(
-            new Solution("user", "password", DEFAULT_NAMESPACE), TEST_CONFIG);
+            new Solution("ditto", "ditto", DEFAULT_NAMESPACE), TEST_CONFIG);
 
     /**
      * Prefix for the Default namespace of the default solution.

--- a/common/src/main/java/org/eclipse/ditto/testing/common/TestSolutionResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/TestSolutionResource.java
@@ -19,6 +19,7 @@ import org.eclipse.ditto.jwt.model.JsonWebToken;
 import org.eclipse.ditto.testing.common.authentication.AccessTokenSupplier;
 import org.eclipse.ditto.testing.common.authentication.AccessTokenSuppliers;
 import org.eclipse.ditto.testing.common.authentication.OAuthMockConfig;
+import org.eclipse.ditto.testing.common.client.oauth.AuthConfig;
 import org.eclipse.ditto.testing.common.config.TestConfig;
 import org.eclipse.ditto.testing.common.config.TestEnvironment;
 import org.junit.rules.ExternalResource;
@@ -46,11 +47,13 @@ public final class TestSolutionResource extends ExternalResource
     private final TestConfig testConfig;
     private Solution solution;
     private AccessTokenSupplier<JsonWebToken> accessTokenSupplier;
+    private final boolean basicAuthEnabled;
 
     private TestSolutionResource(final TestConfig testConfig) {
         this.testConfig = testConfig;
         solution = null;
         accessTokenSupplier = null;
+        basicAuthEnabled = CommonTestConfig.getInstance().getBasicAuth().isEnabled();
     }
 
     /**
@@ -68,7 +71,26 @@ public final class TestSolutionResource extends ExternalResource
     @Override
     protected void before() throws Throwable {
         solution = createDefaultSolution();
-        accessTokenSupplier = getCachingAuthMockJwtSupplier();
+        if (!basicAuthEnabled) {
+            if (isLocalOrDockerEnvironment()) {
+                accessTokenSupplier = getCachingAuthMockJwtSupplier();
+            } else {
+                final var authConfig = AuthConfig.of(testConfig);
+                accessTokenSupplier = getCachingAuthJwtSupplier(authConfig);
+            }
+        }
+    }
+
+    private boolean isLocalOrDockerEnvironment() {
+        final var testEnvironment = testConfig.getTestEnvironment();
+        return TestEnvironment.LOCAL == testEnvironment || TestEnvironment.DOCKER_COMPOSE == testEnvironment;
+    }
+
+    private AccessTokenSupplier<JsonWebToken> getCachingAuthJwtSupplier(final AuthConfig authConfig) {
+        return AccessTokenSuppliers.getCachingAuthJwtSupplier(authConfig.getTokenEndpointUri(),
+                authConfig.getClientId(),
+                authConfig.getClientSecret(),
+                authConfig.getClientScope());
     }
 
     private AccessTokenSupplier<JsonWebToken> getCachingAuthMockJwtSupplier() {

--- a/common/src/main/java/org/eclipse/ditto/testing/common/TestSolutionResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/TestSolutionResource.java
@@ -62,9 +62,7 @@ public final class TestSolutionResource extends ExternalResource
      */
     public static TestSolutionResource newInstance(final TestConfig testConfig) {
         ConditionChecker.checkNotNull(testConfig, "testConfig");
-        return new TestSolutionResource(
-                testConfig
-        );
+        return new TestSolutionResource(testConfig);
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/ditto/testing/common/TestingContext.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/TestingContext.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.testing.common;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import org.asynchttpclient.AsyncHttpClient;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.client.http.AsyncHttpClientFactory;
 import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
 
@@ -29,10 +30,12 @@ public final class TestingContext {
 
     private final Solution solution;
     private final AuthClient oAuthClient;
+    private final BasicAuth basicAuth;
 
-    private TestingContext(final Solution solution, final AuthClient oAuthClient) {
+    private TestingContext(final Solution solution, final AuthClient oAuthClient, final BasicAuth basicAuth) {
         this.solution = solution;
         this.oAuthClient = oAuthClient;
+        this.basicAuth = basicAuth;
     }
 
     public Solution getSolution() {
@@ -43,10 +46,16 @@ public final class TestingContext {
         return oAuthClient;
     }
 
-    public static TestingContext newInstance(final Solution solution, final AuthClient oAuthClient) {
+    public BasicAuth getBasicAuth() {
+        return basicAuth;
+    }
+
+    public static TestingContext newInstance(final Solution solution, final AuthClient oAuthClient,
+            final BasicAuth basicAuth) {
         checkNotNull(solution, "solution");
         checkNotNull(oAuthClient, "oAuthClient");
-        return new TestingContext(solution, oAuthClient);
+        checkNotNull(basicAuth, "BasicAuth");
+        return new TestingContext(solution, oAuthClient, basicAuth);
     }
 
     public static TestingContext withGeneratedMockClient(final Solution solution, final CommonTestConfig config) {
@@ -60,7 +69,7 @@ public final class TestingContext {
                 DEFAULT_SCOPE,
                 httpClient);
 
-        return newInstance(solution, oAuthClient);
+        return newInstance(solution, oAuthClient, config.getBasicAuth());
     }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/TestingContext.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/TestingContext.java
@@ -67,7 +67,9 @@ public final class TestingContext {
                 solution.getUsername(),
                 solution.getSecret(),
                 DEFAULT_SCOPE,
-                httpClient);
+                httpClient,
+                solution.getUsername(),
+                solution.getUsername());
 
         return newInstance(solution, oAuthClient, config.getBasicAuth());
     }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/VersionedSearchIntegrationTest.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/VersionedSearchIntegrationTest.java
@@ -91,8 +91,7 @@ public abstract class VersionedSearchIntegrationTest extends SearchIntegrationTe
     }
 
     protected ThingId persistThingAndWaitTillAvailable(final Thing thing) {
-        return persistThingAndWaitTillAvailable(thing, apiVersion,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+        return persistThingAndWaitTillAvailable(thing, apiVersion, serviceEnv.getDefaultTestingContext());
     }
 
     private static Optional<List<JsonSchemaVersion>> getConfiguredApiVersions() {

--- a/common/src/main/java/org/eclipse/ditto/testing/common/authentication/AuthenticationSetters.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/authentication/AuthenticationSetters.java
@@ -16,6 +16,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.common.ConditionChecker;
 import org.eclipse.ditto.jwt.model.JsonWebToken;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 
 /**
  * Provides {@link AuthenticationSetter}s for various authentication schemes.
@@ -52,6 +53,16 @@ public final class AuthenticationSetters {
      */
     public static AuthenticationSetter devopsAuthentication() {
         return authSpec -> authSpec.preemptive().basic("devops", "foobar");
+    }
+
+    /**
+     * Gets an {@link AuthenticationSetter} that uses "ditto" username and password as
+     * preemptive basic auth authentication.
+     *
+     * @return the {@code AuthenticationSetter}.
+     */
+    public static AuthenticationSetter basicAuthentication(BasicAuth basicAuth) {
+        return authSpec -> authSpec.preemptive().basic(basicAuth.getUsername(), basicAuth.getPassword());
     }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/authentication/OAuthMockResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/authentication/OAuthMockResource.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.testing.common.junit.ExternalResourcePlus;
 import org.junit.runner.Description;
 
 /**
- * This external resource registers a client at the Suite Auth Mock and provides access tokens for that client.
+ * This external resource registers a client at the OAuth Mock and provides access tokens for that client.
  * To register the client, the service instance ID of the solution is used, that is provided by the
  * {@link TestSolutionSupplierRule}.
  * <p>

--- a/common/src/main/java/org/eclipse/ditto/testing/common/client/BasicAuth.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/client/BasicAuth.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.testing.common.client;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+/**
+ * Utility class for Basic Auth properties.
+ */
+public final class BasicAuth {
+
+    private final boolean enabled;
+    private final String username;
+    private final String password;
+
+    private BasicAuth(final boolean enabled,
+            final String username,
+            final String password
+        ) {
+
+        this.enabled = enabled;
+        this.username = username;
+        this.password = password;
+    }
+
+    public static BasicAuth newInstance(final Boolean enabled,
+            final String username,
+            final String password
+    ) {
+
+        checkNotNull(enabled, "enabled");
+        if (Boolean.TRUE.equals(enabled)) {
+            checkNotNull(username, "username");
+            checkNotNull(password, "password");
+        }
+
+        return new BasicAuth(enabled, username, password);
+    }
+
+    /**
+     * Returns if the Basic Auth enabled or not
+     *
+     * @return the enabled flag.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns the Basic Auth client username
+     *
+     * @return the username.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Returns the Basic Auth password.
+     *
+     * @return the password.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/common/src/main/java/org/eclipse/ditto/testing/common/client/BasicAuth.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/client/BasicAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthClient.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthClient.java
@@ -32,13 +32,15 @@ public final class AuthClient extends CommonOAuth2Client {
             final String clientId,
             final String clientSecret,
             final String scope,
-            final AsyncHttpClient httpClient) {
+            final AsyncHttpClient httpClient,
+            final String subject,
+            final String defaultSubject) {
 
         super(tokenEndpoint, clientId, clientSecret, scope, httpClient);
-        this.subject = Subject.newInstance(subjectIssuer, clientId, SubjectType.newInstance("ditto-auth"));
-
+        this.subject =
+                Subject.newInstance(subjectIssuer, subject, SubjectType.newInstance("ditto-auth"));
         this.defaultSubject =
-                Subject.newInstance(subjectIssuer, clientId, SubjectType.newInstance("ditto-auth"));
+                Subject.newInstance(subjectIssuer, defaultSubject, SubjectType.newInstance("ditto-auth"));
     }
 
     public static AuthClient newInstance(final String tokenEndpoint,
@@ -46,16 +48,19 @@ public final class AuthClient extends CommonOAuth2Client {
             final String clientId,
             final String clientSecret,
             final String scope,
-            final AsyncHttpClient httpClient) {
+            final AsyncHttpClient httpClient,
+            final String subject,
+            final String defaultSubject) {
 
         checkNotNull(subjectIssuer, "subjectIssuer");
         checkNotNull(scope, "scope");
+        checkNotNull(subject, "subject");
 
-        return new AuthClient(tokenEndpoint, subjectIssuer, clientId, clientSecret, scope, httpClient);
+        return new AuthClient(tokenEndpoint, subjectIssuer, clientId, clientSecret, scope, httpClient, subject, defaultSubject);
     }
 
     /**
-     * Returns the Suite Auth client id subject, e.g. ditto:0a61b502-4ce2-4d11-a962-80f6d3521875
+     * Returns the OAuth client id subject, e.g. ditto:0a61b502-4ce2-4d11-a962-80f6d3521875
      *
      * @return the subject.
      */

--- a/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.testing.common.client.oauth;
+
+import java.net.URI;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.ConditionChecker;
+import org.eclipse.ditto.testing.common.config.TestConfig;
+
+/**
+ * Configuration properties for Suite Auth service.
+ */
+@Immutable
+public final class AuthConfig {
+
+    private static final String OAUTH_PREFIX = "oauth.";
+    private static final String OAUTH_TOKEN_ENDPOINT = OAUTH_PREFIX + "tokenEndpoint";
+    private static final String OAUTH_AUTHORIZE_ENDPOINT = OAUTH_PREFIX + "authorizeEndpoint";
+    private static final String OAUTH_CLIENT_ID = OAUTH_PREFIX + "clientId";
+    private static final String OAUTH_CLIENT_SECRET = OAUTH_PREFIX + "clientSecret";
+    private static final String OAUTH_CLIENT_SCOPE = OAUTH_PREFIX + "clientScope";
+
+    private final URI tokenEndpointUri;
+    private final String clientId;
+    private final String clientSecret;
+    private final String clientScope;
+
+    private AuthConfig(final TestConfig config) {
+        tokenEndpointUri = config.getUriOrThrow(OAUTH_TOKEN_ENDPOINT);
+        clientId = config.getStringOrThrow(OAUTH_CLIENT_ID);
+        clientSecret = config.getStringOrThrow(OAUTH_CLIENT_SECRET);
+        clientScope = config.getStringOrThrow(OAUTH_CLIENT_SCOPE);
+    }
+
+    /**
+     * Returns an instance of {@code SuiteAuthConfig}.
+     *
+     * @param testConfig provides the raw testConfig properties.
+     * @return the instance.
+     * @throws NullPointerException if {@code testConfig} is {@code null}.
+     * @throws org.eclipse.ditto.testing.common.config.ConfigError if any config property is either missing or has an
+     * inappropriate value.
+     */
+    public static AuthConfig of(final TestConfig testConfig) {
+        return new AuthConfig(ConditionChecker.checkNotNull(testConfig, "testConfig"));
+    }
+
+    public URI getTokenEndpointUri() {
+        return tokenEndpointUri;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getClientScope() {
+        return clientScope;
+    }
+
+}

--- a/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/client/oauth/AuthConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/common/src/main/java/org/eclipse/ditto/testing/common/config/TestConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/config/TestConfig.java
@@ -98,7 +98,7 @@ public final class TestConfig {
                     final var pattern = "Failed to determine test environment: <{0}> is unknown.";
                     throw new ConfigError(MessageFormat.format(pattern, testEnvironmentConfigValue));
                 });
-        LOGGER.info("Running against test environment <{}>.", result);
+        LOGGER.info("Running against test environment <{}>.", result.name());
         return result;
     }
 

--- a/common/src/main/java/org/eclipse/ditto/testing/common/config/TestEnvironment.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/config/TestEnvironment.java
@@ -23,7 +23,9 @@ public enum TestEnvironment {
 
     DOCKER_COMPOSE("docker-compose"),
 
-    LOCAL("local");
+    LOCAL("local"),
+
+    DEPLOYMENT("deployment");
 
     private final String configValue;
 

--- a/common/src/main/java/org/eclipse/ditto/testing/common/gateway/GatewayConfig.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/gateway/GatewayConfig.java
@@ -17,6 +17,8 @@ import java.net.URI;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.common.ConditionChecker;
+import org.eclipse.ditto.testing.common.CommonTestConfig;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.config.TestConfig;
 
 /**
@@ -32,12 +34,14 @@ public final class GatewayConfig {
 
     private final URI httpUriApi2;
     private final URI webSocketUriApi2;
+    private final BasicAuth basicAuth;
 
     private GatewayConfig(final TestConfig testConfig) {
         final var gatewayHttpUri = testConfig.getUriOrThrow(HTTP_URL_CONFIG_PATH);
         httpUriApi2 = gatewayHttpUri.resolve("/api/2/");
         final var gatewayWebSocketUri = testConfig.getUriOrThrow(WEBSOCKET_URL_CONFIG_PATH);
         webSocketUriApi2 = gatewayWebSocketUri.resolve("/ws/2");
+        basicAuth = CommonTestConfig.getInstance().getBasicAuth();
     }
 
     /**
@@ -61,4 +65,7 @@ public final class GatewayConfig {
         return webSocketUriApi2;
     }
 
+    public BasicAuth getBasicAuth() {
+        return basicAuth;
+    }
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/matcher/RestMatcherConfigurer.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/matcher/RestMatcherConfigurer.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.testing.common.HttpHeader;
+import org.eclipse.ditto.testing.common.TestingContext;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 
 /**
  * Configures Rest Matchers.
@@ -25,30 +27,50 @@ public final class RestMatcherConfigurer {
 
     @Nullable private final String jwt;
     @Nullable private final PreAuthenticatedAuth preAuthenticatedAuth;
+    @Nullable private final BasicAuth basicAuth;
 
     private RestMatcherConfigurer(@Nullable final String jwt,
-            @Nullable final PreAuthenticatedAuth preAuthenticatedAuth) {
+            @Nullable final PreAuthenticatedAuth preAuthenticatedAuth,
+            @Nullable final BasicAuth basicAuth) {
         this.jwt = jwt;
         this.preAuthenticatedAuth = preAuthenticatedAuth;
+        this.basicAuth = basicAuth;
     }
 
     public static RestMatcherConfigurer empty() {
-        return new RestMatcherConfigurer(null, null);
+        return new RestMatcherConfigurer(null, null, null);
     }
 
     public static RestMatcherConfigurer withJwt(final String jwt) {
-        return new RestMatcherConfigurer(jwt, null);
+        return new RestMatcherConfigurer(jwt, null, null);
+    }
+
+    public static RestMatcherConfigurer withBasicAuth(final BasicAuth basicAuth) {
+        return new RestMatcherConfigurer(null, null, basicAuth);
+    }
+
+    public static RestMatcherConfigurer withConfiguredAuth(TestingContext context) {
+        final BasicAuth ba = context.getBasicAuth();
+        if (null != ba && ba.isEnabled()) {
+            return new RestMatcherConfigurer(null, null, BasicAuth.newInstance(true, ba.getUsername(), ba.getPassword()));
+        } else {
+            return new RestMatcherConfigurer(context.getOAuthClient().getAccessToken(), null, null);
+        }
     }
 
     public <T extends HttpVerbMatcher> T configure(final T matcher) {
         matcher.withHeader(HttpHeader.X_CORRELATION_ID, String.valueOf(UUID.randomUUID()));
 
-        if (null != jwt) {
-            matcher.withJWT(jwt);
-        }
+        if (null != basicAuth && basicAuth.isEnabled()) {
+            matcher.withBasicAuth(basicAuth.getUsername(), basicAuth.getPassword());
+        } else {
+            if (null != jwt) {
+                matcher.withJWT(jwt);
+            }
 
-        if (null != preAuthenticatedAuth) {
-            matcher.withPreAuthenticatedAuth(preAuthenticatedAuth);
+            if (null != preAuthenticatedAuth) {
+                matcher.withPreAuthenticatedAuth(preAuthenticatedAuth);
+            }
         }
 
         return matcher;

--- a/common/src/main/java/org/eclipse/ditto/testing/common/matcher/RestMatcherConfigurer.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/matcher/RestMatcherConfigurer.java
@@ -50,9 +50,9 @@ public final class RestMatcherConfigurer {
     }
 
     public static RestMatcherConfigurer withConfiguredAuth(TestingContext context) {
-        final BasicAuth ba = context.getBasicAuth();
-        if (null != ba && ba.isEnabled()) {
-            return new RestMatcherConfigurer(null, null, BasicAuth.newInstance(true, ba.getUsername(), ba.getPassword()));
+        final BasicAuth basicAuth = context.getBasicAuth();
+        if (null != basicAuth && basicAuth.isEnabled()) {
+            return new RestMatcherConfigurer(null, null, BasicAuth.newInstance(true, basicAuth.getUsername(), basicAuth.getPassword()));
         } else {
             return new RestMatcherConfigurer(context.getOAuthClient().getAccessToken(), null, null);
         }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/policies/PoliciesHttpClientResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/policies/PoliciesHttpClientResource.java
@@ -45,8 +45,13 @@ public final class PoliciesHttpClientResource extends ExternalResource {
             final AccessTokenSupplier<JsonWebToken> jwtSupplier) {
 
         final var gatewayConfig = GatewayConfig.of(testConfig);
-        return new PoliciesHttpClientResource(gatewayConfig.getHttpUriApi2(),
-                AuthenticationSetters.oauth2AccessToken(jwtSupplier));
+        if (gatewayConfig.getBasicAuth().isEnabled()) {
+            return new PoliciesHttpClientResource(gatewayConfig.getHttpUriApi2(),
+                    AuthenticationSetters.basicAuthentication(gatewayConfig.getBasicAuth()));
+        } else {
+            return new PoliciesHttpClientResource(gatewayConfig.getHttpUriApi2(),
+                    AuthenticationSetters.oauth2AccessToken(jwtSupplier));
+        }
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/ditto/testing/common/things/ThingsHttpClient.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/things/ThingsHttpClient.java
@@ -138,6 +138,10 @@ public final class ThingsHttpClient {
         checkNotNull(thingId, "thingId");
     }
 
+    private static void requirePolicyIdNotNull(final PolicyId policyId) {
+        checkNotNull(policyId, "policyId");
+    }
+
     private static void requireThingNotNull(final Thing thing) {
         checkNotNull(thing, "thing");
     }
@@ -293,6 +297,23 @@ public final class ThingsHttpClient {
             RestAssured.given(getBasicRequestSpec(correlationId, Set.of(HttpStatus.SC_NO_CONTENT), filter))
                     .delete("/{thingId}", thingId.toString());
             LOGGER.info("Deleted thing <{}>.", thingId);
+        } finally {
+            LOGGER.discardCorrelationId();
+        }
+    }
+
+    public void deletePolicy(final PolicyId policyId, final CorrelationId correlationId, final Filter... filter) {
+        requirePolicyIdNotNull(policyId);
+        requireCorrelationIdNotNull(correlationId);
+        requireFilterNotNull(filter);
+
+        LOGGER.withCorrelationId(correlationId);
+        LOGGER.info("Deleting policy <{}> …", policyId);
+
+        try {
+            RestAssured.given(getBasicRequestSpec(correlationId, Set.of(HttpStatus.SC_NO_CONTENT), filter))
+                    .delete("/{policyId}", policyId.toString());
+            LOGGER.info("Deleted policy <{}>.", policyId);
         } finally {
             LOGGER.discardCorrelationId();
         }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/things/ThingsHttpClientResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/things/ThingsHttpClientResource.java
@@ -51,8 +51,13 @@ public final class ThingsHttpClientResource extends ExternalResource {
             final AccessTokenSupplier<JsonWebToken> jwtSupplier) {
 
         final var gatewayConfig = GatewayConfig.of(testConfig);
-        return new ThingsHttpClientResource(gatewayConfig.getHttpUriApi2(),
-                AuthenticationSetters.oauth2AccessToken(jwtSupplier));
+        if (gatewayConfig.getBasicAuth().isEnabled()) {
+            return new ThingsHttpClientResource(gatewayConfig.getHttpUriApi2(),
+                    AuthenticationSetters.basicAuthentication(gatewayConfig.getBasicAuth()));
+        } else {
+            return new ThingsHttpClientResource(gatewayConfig.getHttpUriApi2(),
+                    AuthenticationSetters.oauth2AccessToken(jwtSupplier));
+        }
     }
 
     @Override

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebSocketClientFactory.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebSocketClientFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.ditto.base.model.common.ConditionChecker;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.jwt.model.JsonWebToken;
 import org.eclipse.ditto.testing.common.authentication.AccessTokenSupplier;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.config.TestConfig;
 import org.eclipse.ditto.testing.common.gateway.GatewayConfig;
 import org.eclipse.ditto.testing.common.http.HttpProxyConfig;
@@ -36,6 +37,7 @@ public final class ThingsWebSocketClientFactory {
 
     public static ThingsWebsocketClient getWebSocketClient(final TestConfig testConfig,
             final AccessTokenSupplier<JsonWebToken> jwtSupplier,
+            final BasicAuth basicAuth,
             final DittoHeaders additionalHeaders) {
 
         ConditionChecker.checkNotNull(testConfig, "testConfig");
@@ -45,9 +47,10 @@ public final class ThingsWebSocketClientFactory {
         final var jsonWebToken = jwtSupplier.getAccessToken();
         return ThingsWebsocketClient.newInstance(getEndpoint(testConfig),
                 jsonWebToken.getToken(),
+                basicAuth,
                 additionalHeaders,
                 getProxyServerOrNull(testConfig),
-                ThingsWebsocketClient.JwtAuthMethod.HEADER);
+                ThingsWebsocketClient.AuthMethod.HEADER);
     }
 
     private static String getEndpoint(final TestConfig testConfig) {

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebSocketClientResource.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebSocketClientResource.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.jwt.model.JsonWebToken;
 import org.eclipse.ditto.testing.common.authentication.AccessTokenSupplier;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.config.TestConfig;
 import org.eclipse.ditto.testing.common.correlationid.CorrelationId;
 import org.junit.rules.ExternalResource;
@@ -66,7 +67,10 @@ public final class ThingsWebSocketClientResource extends ExternalResource {
     }
 
     private ThingsWebsocketClient createThingsWebsocketClient() {
-        return ThingsWebSocketClientFactory.getWebSocketClient(testConfig, jwtSupplier, DittoHeaders.empty());
+        // Mock basicAuth parameter as no acceptance tests uses this method
+        final BasicAuth basicAuth = BasicAuth.newInstance(false, "", "");
+
+        return ThingsWebSocketClientFactory.getWebSocketClient(testConfig, jwtSupplier, basicAuth, DittoHeaders.empty());
     }
 
     private static void connect(final ThingsWebsocketClient thingsWebsocketClient) {

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
@@ -601,7 +601,6 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
          * The authentication is passed as query parameter 'ws/2?access_token=[jwt]' or 'ws/2?basic=[user:pass]'
          */
         QUERY_PARAM
-
     }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.testing.common.ws;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -53,6 +55,7 @@ import org.eclipse.ditto.protocol.ProtocolFactory;
 import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
 import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
 import org.eclipse.ditto.testing.common.HttpHeader;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.client.ditto_protocol.DittoProtocolClient;
 import org.eclipse.ditto.testing.common.client.ditto_protocol.HeaderBlocklistChecker;
 import org.eclipse.ditto.testing.common.client.ditto_protocol.options.Option;
@@ -84,22 +87,21 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
     private final DefaultAsyncHttpClient client;
     private final ProtocolAdapter protocolAdapter;
     private final String endpoint;
-    private final String jwt;
 
     private final AtomicReference<WebSocket> webSocketReference = new AtomicReference<>();
     private final AtomicReference<Consumer<Adaptable>> adaptableConsumerReference = new AtomicReference<>();
     private final ConcurrentHashMap<String, PendingResponse> pendingResponses;
     private final ConcurrentHashMap<String, CompletableFuture<Void>> waitForAckStages;
     private final Map<String, String> additionalHttpHeaders;
-    private final JwtAuthMethod authMethod;
 
     private final List<Throwable> errors;
 
-    private ThingsWebsocketClient(final String endpoint,
+    private ThingsWebsocketClient(String endpoint,
             final String jwt,
+            final BasicAuth basicAuth,
             final Map<String, String> additionalHttpHeaders,
             @Nullable final ProxyServer proxyServer,
-            final JwtAuthMethod authMethod) {
+            final AuthMethod authMethod) {
 
         final var configBuilder = new DefaultAsyncHttpClientConfig.Builder();
         configBuilder.setThreadPoolName("things-ws");
@@ -113,23 +115,39 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
 
         client = new DefaultAsyncHttpClient(configBuilder.build());
         protocolAdapter = DittoProtocolAdapter.of(HeaderTranslator.empty());
-        this.endpoint = endpoint;
-        this.jwt = jwt;
+        this.additionalHttpHeaders = new HashMap<>(additionalHttpHeaders);
+        final StringBuilder queryParams = new StringBuilder(endpoint);
+        if (basicAuth.isEnabled()) {
+            final String basicAuthEncoded = Base64.getEncoder().encodeToString(
+                    (basicAuth.getUsername() + ":" + basicAuth.getPassword()).getBytes());
+            if (authMethod == AuthMethod.QUERY_PARAM) {
+                queryParams.append(String.format("?%s=%s", "basic", basicAuthEncoded));
+            } else {
+                this.additionalHttpHeaders.put(HttpHeader.AUTHORIZATION.getName(), "Basic " + basicAuthEncoded);
+            }
+        } else {
+            if (authMethod == AuthMethod.QUERY_PARAM) {
+                queryParams.append(String.format("?%s=%s", "access_token", jwt));
+            } else {
+                this.additionalHttpHeaders.put(HttpHeader.AUTHORIZATION.getName(), "Bearer " + jwt);
+            }
+        }
+        this.endpoint = queryParams.toString();
         pendingResponses = new ConcurrentHashMap<>();
         waitForAckStages = new ConcurrentHashMap<>();
-        this.additionalHttpHeaders = Map.copyOf(additionalHttpHeaders);
-        this.authMethod = authMethod;
         this.errors = new ArrayList<>();
     }
 
     public static ThingsWebsocketClient newInstance(final String endpoint,
             final String jwt,
+            final BasicAuth basicAuth,
             final Map<String, String> additionalHttpHeaders,
             @Nullable final ProxyServer proxyServer,
-            final JwtAuthMethod authMethod) {
+            final AuthMethod authMethod) {
 
         return new ThingsWebsocketClient(ConditionChecker.checkNotNull(endpoint, "endpoint"),
                 ConditionChecker.checkNotNull(jwt, "jwt"),
+                basicAuth,
                 ConditionChecker.checkNotNull(additionalHttpHeaders, "additionalHttpHeaders"),
                 proxyServer,
                 ConditionChecker.checkNotNull(authMethod, "authMethod"));
@@ -157,19 +175,9 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
         final var upgradeHandler = new WebSocketUpgradeHandler.Builder()
                 .addWebSocketListener(this)
                 .build();
-        final String endpointWithParameter;
-        if (authMethod == JwtAuthMethod.QUERY_PARAM) {
-            endpointWithParameter = String.format("%s?%s=%s", endpoint, "access_token", jwt);
-        } else {
-            endpointWithParameter = endpoint;
-        }
 
-        final var requestBuilder = client.prepareGet(endpointWithParameter)
+        final var requestBuilder = client.prepareGet(this.endpoint)
                 .addHeader(HttpHeader.X_CORRELATION_ID.getName(), correlationId);
-
-        if (authMethod == JwtAuthMethod.HEADER) {
-            requestBuilder.addHeader(HttpHeader.AUTHORIZATION.getName(), "Bearer " + jwt);
-        }
 
         additionalHttpHeaders.forEach(requestBuilder::addHeader);
         final var execute = requestBuilder.execute(upgradeHandler);
@@ -566,7 +574,7 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
         }
     }
 
-    public enum JwtAuthMethod {
+    public enum AuthMethod {
 
         /**
          * The JWT is passed as header 'Authorization Bearer [jwt]'
@@ -577,6 +585,7 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
          * The JWT is passed as query parameter 'ws/2?access_token=[jwt]'
          */
         QUERY_PARAM
+
     }
 
 }

--- a/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ws/ThingsWebsocketClient.java
@@ -55,6 +55,7 @@ import org.eclipse.ditto.protocol.ProtocolFactory;
 import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
 import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
 import org.eclipse.ditto.testing.common.HttpHeader;
+import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.client.ditto_protocol.DittoProtocolClient;
 import org.eclipse.ditto.testing.common.client.ditto_protocol.HeaderBlocklistChecker;
@@ -148,6 +149,21 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
         return new ThingsWebsocketClient(ConditionChecker.checkNotNull(endpoint, "endpoint"),
                 ConditionChecker.checkNotNull(jwt, "jwt"),
                 basicAuth,
+                ConditionChecker.checkNotNull(additionalHttpHeaders, "additionalHttpHeaders"),
+                proxyServer,
+                ConditionChecker.checkNotNull(authMethod, "authMethod"));
+    }
+
+    public static ThingsWebsocketClient newInstance(final String endpoint,
+            final TestingContext testingContext,
+            final Map<String, String> additionalHttpHeaders,
+            @Nullable final ProxyServer proxyServer,
+            final AuthMethod authMethod) {
+
+        ConditionChecker.checkNotNull(testingContext, "testingContext");
+        return new ThingsWebsocketClient(ConditionChecker.checkNotNull(endpoint, "endpoint"),
+                testingContext.getBasicAuth().isEnabled() ? "" : testingContext.getOAuthClient().getAccessToken(),
+                testingContext.getBasicAuth(),
                 ConditionChecker.checkNotNull(additionalHttpHeaders, "additionalHttpHeaders"),
                 proxyServer,
                 ConditionChecker.checkNotNull(authMethod, "authMethod"));
@@ -577,12 +593,12 @@ public final class ThingsWebsocketClient implements WebSocketListener, AutoClose
     public enum AuthMethod {
 
         /**
-         * The JWT is passed as header 'Authorization Bearer [jwt]'
+         * The authentication is passed as header 'Authorization Bearer [jwt]' or 'Authorization Basic [user:pass]'
          */
         HEADER,
 
         /**
-         * The JWT is passed as query parameter 'ws/2?access_token=[jwt]'
+         * The authentication is passed as query parameter 'ws/2?access_token=[jwt]' or 'ws/2?basic=[user:pass]'
          */
         QUERY_PARAM
 

--- a/common/src/main/resources/test-common-deployment.conf
+++ b/common/src/main/resources/test-common-deployment.conf
@@ -1,0 +1,42 @@
+mongoDB.uri = ${?MONGODB_URI}
+
+setup.http.proxy {
+  enabled = false
+  enabled = ${?PROXY_ENABLED}
+}
+
+gateway {
+  devops-context-path = devops
+  hostname = ${default.hostname}
+  hostname = ${?GATEWAY_HOSTNAME}
+  url = "https://"${gateway.hostname}
+  ws-url = "wss://"${gateway.hostname}
+
+  devops {
+    url = ${gateway.url}/${gateway.devops-context-path}
+    command-timeout = 30s
+
+    auth.enabled = true
+  }
+  basic-auth {
+    enabled = true
+    enabled = ${?BASIC_AUTH_ENABLED}
+
+    username = "ditto"
+    username = ${?BASIC_AUTH_USERNAME}
+
+    password = "ditto"
+    password = ${?BASIC_AUTH_PASSWORD}
+  }
+}
+
+oauth-mock {
+  hostname = ${docker.gateway.host}
+  hostname = ${?OAUTH_MOCK_HOSTNAME}
+
+  port = 9900
+  port = ${?OAUTH_MOCK_PORT}
+
+  tokenEndpoint = "http://"${oauth-mock.hostname}":"${oauth-mock.port}"/ditto/token"
+  tokenEndpoint = ${?OAUTH_MOCK_ENDPOINT}
+}

--- a/common/src/main/resources/test-common-deployment.conf
+++ b/common/src/main/resources/test-common-deployment.conf
@@ -8,7 +8,8 @@ setup.http.proxy {
 gateway {
   devops-context-path = devops
   hostname = ${default.hostname}
-  hostname = ${?GATEWAY_HOSTNAME}
+  hostname = ${?DEFAULT_HOSTNAME}
+
   url = "https://"${gateway.hostname}
   ws-url = "wss://"${gateway.hostname}
 
@@ -19,7 +20,7 @@ gateway {
     auth.enabled = true
   }
   basic-auth {
-    enabled = true
+    enabled = false
     enabled = ${?BASIC_AUTH_ENABLED}
 
     username = "ditto"
@@ -34,9 +35,28 @@ oauth-mock {
   hostname = ${docker.gateway.host}
   hostname = ${?OAUTH_MOCK_HOSTNAME}
 
-  port = 9900
   port = ${?OAUTH_MOCK_PORT}
-
-  tokenEndpoint = "http://"${oauth-mock.hostname}":"${oauth-mock.port}"/ditto/token"
   tokenEndpoint = ${?OAUTH_MOCK_ENDPOINT}
 }
+
+oauth {
+    tokenEndpoint = ${?OAUTH_TOKEN_ENDPOINT}
+    issuer = ${?OAUTH_ISSUER}
+
+    clientId = ${?OAUTH_CLIENT_ID}
+    clientSecret = ${?OAUTH_CLIENT_SECRET}
+    clientScope = ${?OAUTH_CLIENT_SCOPE}
+
+    client2Id = ${?OAUTH_CLIENT2_ID}
+    client2Secret = ${?OAUTH_CLIENT2_SECRET}
+    client2Scope = ${?OAUTH_CLIENT2_SCOPE}
+
+    client3Id = ${?OAUTH_CLIENT3_ID}
+    client3Secret = ${?OAUTH_CLIENT3_SECRET}
+    client3Scope = ${?OAUTH_CLIENT3_SCOPE}
+
+    client4Id = ${?OAUTH_CLIENT4_ID}
+    client4Secret = ${?OAUTH_CLIENT4_SECRET}
+    client4Scope = ${?OAUTH_CLIENT4_SCOPE}
+}
+

--- a/common/src/main/resources/test-common-local.conf
+++ b/common/src/main/resources/test-common-local.conf
@@ -21,7 +21,3 @@ gateway {
     auth.enabled = false
   }
 }
-
-oauth-mock {
-  tokenEndpoint = "http://localhost:9900/ditto/token"
-}

--- a/common/src/main/resources/test-common-local.conf
+++ b/common/src/main/resources/test-common-local.conf
@@ -21,3 +21,7 @@ gateway {
     auth.enabled = false
   }
 }
+
+oauth-mock {
+  tokenEndpoint = "http://localhost:9900/ditto/token"
+}

--- a/common/src/main/resources/test-common.conf
+++ b/common/src/main/resources/test-common.conf
@@ -88,6 +88,14 @@ oauth-mock {
   tokenEndpoint = "http://"${oauth-mock.hostname}":"${oauth-mock.port}"/ditto/token"
 }
 
+oauth {
+  tokenEndpoint = "http://dummyEndpoint"
+  issuer = "dummyIssuer"
+  clientId = "dummyId"
+  clientSecret = "dummySecret"
+  clientScope = "system-tests"
+}
+
 ditto.protocol {
   blocklist = [
     // do not block headers added by Pekko HTTP

--- a/common/src/main/resources/test-common.conf
+++ b/common/src/main/resources/test-common.conf
@@ -5,7 +5,7 @@ test.environment = "local"
 default.hostname = localhost
 default.hostname = ${?DEFAULT_HOSTNAME}
 
-docker.gateway.host = "localhost"
+docker.gateway.host = "172.17.0.1"
 
 mongoDB.uri = "mongodb://localhost:27017/test"
 

--- a/common/src/main/resources/test-common.conf
+++ b/common/src/main/resources/test-common.conf
@@ -5,7 +5,7 @@ test.environment = "local"
 default.hostname = localhost
 default.hostname = ${?DEFAULT_HOSTNAME}
 
-docker.gateway.host = "172.17.0.1"
+docker.gateway.host = "localhost"
 
 mongoDB.uri = "mongodb://localhost:27017/test"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       - ./fluentbit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
 
   oauth:
-    image: ghcr.io/navikt/mock-oauth2-server:0.5.7
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.3
     networks:
       - test
     expose:

--- a/legal/headers/license-header-2023.txt
+++ b/legal/headers/license-header-2023.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
                 <configuration>
                     <header>${project.basedir}/legal/headers/license-header.txt</header>
                     <validHeaders>
-<!--                        <header>${project.basedir}/legal/headers/license-header-2021.txt</header>-->
+                        <header>${project.basedir}/legal/headers/license-header-2023.txt</header>
                     </validHeaders>
                     <headerDefinitions>
                         <headerDefinition>${project.basedir}/legal/headers/license-header-xml-def.xml</headerDefinition>

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/AbstractClientIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/AbstractClientIT.java
@@ -53,6 +53,7 @@ import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.messages.model.MessageDirection;
 import org.eclipse.ditto.testing.common.IntegrationTest;
 import org.eclipse.ditto.testing.common.Solution;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
 import org.eclipse.ditto.testing.system.client.util.ClientFactory;
 import org.eclipse.ditto.things.model.Thing;
@@ -134,6 +135,15 @@ public abstract class AbstractClientIT extends IntegrationTest {
                 .build());
     }
 
+    protected static DittoClient newDittoClient(final BasicAuth basicAuth, final JsonSchemaVersion schemaVersion) {
+        final AuthenticationProvider<WebSocket> authenticationProvider =
+                AuthenticationProviders.basic(BasicAuthenticationConfiguration.newBuilder()
+                        .username(basicAuth.getUsername())
+                        .password(basicAuth.getPassword())
+                        .build());
+        return newDittoClient(authenticationProvider, schemaVersion, Collections.emptyList(), Collections.emptyList());
+    }
+
     protected static DittoClient newDittoClient(final Solution solution, final JsonSchemaVersion schemaVersion) {
         final AuthenticationProvider<WebSocket> authenticationProvider =
                 AuthenticationProviders.basic(BasicAuthenticationConfiguration.newBuilder()
@@ -169,7 +179,7 @@ public abstract class AbstractClientIT extends IntegrationTest {
 
     protected static ThingId postEmptyThing() {
         final Response response = postThing(JsonSchemaVersion.V_2.toInt(), JsonFactory.newObject())
-                .withJWT(serviceEnv.getDefaultTestingContext().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getDefaultTestingContext())
                 .fire();
         return ThingId.of(parseIdFromLocation(response.getHeader("Location")));
     }

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/authentication/AuthenticationIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/authentication/AuthenticationIT.java
@@ -43,9 +43,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests Client JWT Authentication.
  */
-public final class JwtAuthenticationIT extends AbstractClientIT {
+public final class AuthenticationIT extends AbstractClientIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthenticationIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationIT.class);
 
     private DittoClient dittoClient;
     private ThingId thingId;

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/authentication/JwtAuthenticationIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/authentication/JwtAuthenticationIT.java
@@ -63,6 +63,7 @@ public final class JwtAuthenticationIT extends AbstractClientIT {
         if (dittoClient != null) {
             try {
                 dittoClient.twin().delete(thingId).toCompletableFuture().get(TIMEOUT_SECONDS, SECONDS);
+                dittoClient.policies().delete(PolicyId.of(thingId));
             } catch (final Exception e) {
                 LOGGER.error("Error during Test", e);
             } finally {
@@ -84,8 +85,6 @@ public final class JwtAuthenticationIT extends AbstractClientIT {
         }
         final Thing thing = dittoClient.twin().create(thingId).toCompletableFuture().get();
         assertThat(thing).isNotNull();
-        dittoClient.twin().delete(thingId).toCompletableFuture().get();
-        dittoClient.policies().delete(PolicyId.of(thingId));
     }
 
     private static DittoClient buildClient(final JsonWebTokenSupplier jsonWebTokenSupplier) {
@@ -102,7 +101,8 @@ public final class JwtAuthenticationIT extends AbstractClientIT {
     }
 
     private static DittoClient buildClient(final BasicAuth basicAuth) {
-        final BasicAuthenticationConfiguration.BasicAuthenticationConfigurationBuilder configurationBuilder = BasicAuthenticationConfiguration.newBuilder()
+        final BasicAuthenticationConfiguration.BasicAuthenticationConfigurationBuilder configurationBuilder =
+                BasicAuthenticationConfiguration.newBuilder()
                 .username(basicAuth.getUsername())
                 .password(basicAuth.getPassword());
         if (null != proxyConfiguration()) {

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/messages/HandleFeatureMessagesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/messages/HandleFeatureMessagesIT.java
@@ -269,14 +269,14 @@ public final class HandleFeatureMessagesIT extends AbstractClientIT {
         // not authorized = forbidden
         postMessage(2, thingId, FEATURE_ID_1, FROM, "subject", "text/plain",
                 "test message", TIMEOUT)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .fire();
 
         // no WRITE access = forbidden
         postMessage(2, thingId, FEATURE_ID_1, FROM, "subject", "text/plain",
                 "test message", TIMEOUT)
-                .withJWT(serviceEnv.getTestingContext3().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext3())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .fire();
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/smoke/SmokeIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/smoke/SmokeIT.java
@@ -60,9 +60,10 @@ public final class SmokeIT extends AbstractClientIT {
     public void setUp() {
         final BasicAuth basicAuth = serviceEnv.getDefaultTestingContext().getBasicAuth();
         basicAuthEnabled = basicAuth.isEnabled();
-        final AuthClient oAuthClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
+        final AuthClient oAuthClient1 = serviceEnv.getDefaultTestingContext().getOAuthClient();
+        final AuthClient oAuthClient2 = serviceEnv.getTestingContext2().getOAuthClient();
         TestingContext testingContextForDittoClientSubscriber =
-                TestingContext.newInstance(serviceEnv.getDefaultTestingContext().getSolution(), oAuthClient, basicAuth);
+                TestingContext.newInstance(serviceEnv.getDefaultTestingContext().getSolution(), oAuthClient1, basicAuth);
 
         if (basicAuthEnabled) {
             dittoClient = newDittoClient(basicAuth, JsonSchemaVersion.V_2);
@@ -70,10 +71,9 @@ public final class SmokeIT extends AbstractClientIT {
             subjects = Subjects.newInstance(
                     Subject.newInstance(SubjectIssuer.newInstance("nginx"), basicAuth.getUsername()));
         } else {
-            dittoClient = newDittoClient(serviceEnv.getDefaultTestingContext().getOAuthClient());
+            dittoClient = newDittoClient(oAuthClient1);
             dittoClientSubscriber = newDittoClient(testingContextForDittoClientSubscriber.getOAuthClient());
-            subjects = Subjects.newInstance(oAuthClient.getDefaultSubject(),
-                    serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject());
+            subjects = Subjects.newInstance(oAuthClient1.getDefaultSubject(), oAuthClient2.getDefaultSubject());
         }
     }
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/client/smoke/SmokeIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/client/smoke/SmokeIT.java
@@ -28,8 +28,13 @@ import org.eclipse.ditto.client.DittoClient;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
+import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
 import org.eclipse.ditto.testing.system.client.AbstractClientIT;
 import org.eclipse.ditto.testing.system.client.util.ThingFactory;
 import org.eclipse.ditto.things.model.Thing;
@@ -48,15 +53,28 @@ public final class SmokeIT extends AbstractClientIT {
 
     private DittoClient dittoClient;
     private DittoClient dittoClientSubscriber;
+    private Subjects subjects;
+    private boolean basicAuthEnabled;
 
     @Before
     public void setUp() {
+        final BasicAuth basicAuth = serviceEnv.getDefaultTestingContext().getBasicAuth();
+        basicAuthEnabled = basicAuth.isEnabled();
+        final AuthClient oAuthClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
         TestingContext testingContextForDittoClientSubscriber =
-                TestingContext.newInstance(serviceEnv.getDefaultTestingContext().getSolution(),
-                        serviceEnv.getDefaultTestingContext().getOAuthClient());
+                TestingContext.newInstance(serviceEnv.getDefaultTestingContext().getSolution(), oAuthClient, basicAuth);
 
-        dittoClient = newDittoClient(serviceEnv.getDefaultTestingContext().getOAuthClient());
-        dittoClientSubscriber = newDittoClient(testingContextForDittoClientSubscriber.getOAuthClient());
+        if (basicAuthEnabled) {
+            dittoClient = newDittoClient(basicAuth, JsonSchemaVersion.V_2);
+            dittoClientSubscriber = newDittoClient(basicAuth, JsonSchemaVersion.V_2);
+            subjects = Subjects.newInstance(
+                    Subject.newInstance(SubjectIssuer.newInstance("nginx"), basicAuth.getUsername()));
+        } else {
+            dittoClient = newDittoClient(serviceEnv.getDefaultTestingContext().getOAuthClient());
+            dittoClientSubscriber = newDittoClient(testingContextForDittoClientSubscriber.getOAuthClient());
+            subjects = Subjects.newInstance(oAuthClient.getDefaultSubject(),
+                    serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject());
+        }
     }
 
     @After
@@ -73,10 +91,16 @@ public final class SmokeIT extends AbstractClientIT {
 
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
         final Thing thing = ThingFactory.newThing(thingId);
-        final Policy policy = newPolicy(PolicyId.of(thingId),
-                serviceEnv.getDefaultTestingContext().getOAuthClient(),
-                serviceEnv.getTestingContext2().getOAuthClient());
-
+        final Policy policy;
+        if (basicAuthEnabled) {
+            policy = newPolicy(PolicyId.of(thingId),
+                    Subject.newInstance(SubjectIssuer.newInstance("nginx"),
+                            serviceEnv.getDefaultTestingContext().getBasicAuth().getUsername()));
+        } else {
+            policy = newPolicy(PolicyId.of(thingId),
+                    serviceEnv.getDefaultTestingContext().getOAuthClient(),
+                    serviceEnv.getTestingContext2().getOAuthClient());
+        }
         LOGGER.info("The THING to be inserted: {}", thing.toJsonString(JsonSchemaVersion.V_2));
 
         registerForThingChange(dittoClientSubscriber, thingId, createLatch, modifiedLatch, deleteLatch);
@@ -97,6 +121,7 @@ public final class SmokeIT extends AbstractClientIT {
                         LOGGER.error("Error in Test", throwable);
                     }
                     dittoClient.twin().delete(thingId);
+                    dittoClient.policies().delete(policy.getEntityId().get());
                 })
                 .toCompletableFuture()
                 .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -116,8 +141,8 @@ public final class SmokeIT extends AbstractClientIT {
         final Thing thing = ThingFactory.newThing(thingId);
         final Policy policy = Policy.newBuilder()
                 .forLabel("DEFAULT")
-                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getDefaultSubject())
-                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject())
+                .setSubjects(subjects)
+                .setSubject(SubjectIssuer.newInstance("nginx"), "ditto")
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ, WRITE)
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), READ, WRITE)
                 .setGrantedPermissions(PoliciesResourceType.messageResource("/"), READ, WRITE)
@@ -134,16 +159,16 @@ public final class SmokeIT extends AbstractClientIT {
                     }
                     try {
                         putThingWithPolicy(2, thing, policy, JsonSchemaVersion.V_2)
-                                .withJWT(serviceEnv.getDefaultTestingContext().getOAuthClient().getAccessToken())
+                                .withConfiguredAuth(serviceEnv.getDefaultTestingContext())
                                 .expectingHttpStatus(HttpStatus.CREATED)
                                 .fire();
                         final Thing modified = thing.setAttribute("hello", "world");
                         putThing(2, modified, JsonSchemaVersion.V_2)
-                                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                                .withConfiguredAuth(serviceEnv.getTestingContext2())
                                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                                 .fire();
                         deleteThing(2, thingId)
-                                .withJWT(serviceEnv.getDefaultTestingContext().getOAuthClient().getAccessToken())
+                                .withConfiguredAuth(serviceEnv.getDefaultTestingContext())
                                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                                 .fire();
                     } catch (final Exception e) {

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10ConnectivityIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10ConnectivityIT.java
@@ -200,7 +200,7 @@ public class Amqp10ConnectivityIT extends AbstractConnectivityITestCases<Blockin
         // expect all messages are processed
         getThing(2, thingId)
                 .withParam("fields", "_revision")
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .useAwaitility(Awaitility.await()
                         .pollInterval(Duration.ofSeconds(1))
                         .atMost(Duration.ofMinutes(1)))

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10HonoConnectivityIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10HonoConnectivityIT.java
@@ -308,7 +308,7 @@ public class Amqp10HonoConnectivityIT extends AbstractConnectivityITCommon<Block
 
         // get the thing via http-api
         final Response response = getThing(2, thingId)
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .expectingHttpStatus(HttpStatus.OK)
                 .useAwaitility(Awaitility.await().atMost(Duration.ofSeconds(10)))
                 .withLogging(LOGGER, "thing")

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10PublisherCongestionIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/amqp10/Amqp10PublisherCongestionIT.java
@@ -180,20 +180,20 @@ public class Amqp10PublisherCongestionIT extends AbstractConnectivityITCommon<Bl
                 .build();
 
         putThingWithPolicy(2, thing, policy, V_2)
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
         // WHEN: connection1 is flooded with enough events to fill the 100 element queue and 10 sending futures
         IntStream.range(0, 1010)
                 .forEach(i -> putAttribute(2, thingId, "x", "5")
-                        .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                        .withConfiguredAuth(testingContextWithRandomNs)
                         .expectingStatusCodeSuccessful()
                         .fire());
 
         // THEN: connection1 drops subsequent events
         final Response response = putAttribute(2, thingId, "x", "5")
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .withHeader("requested-acks", ConnectionModelFactory.toAcknowledgementLabel(
                         cf.getConnectionId(cf.connectionName1),
                         defaultTargetAddress(cf.connectionName1))

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/kafka/HonoConnectivityIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/kafka/HonoConnectivityIT.java
@@ -234,7 +234,7 @@ public final class HonoConnectivityIT extends
         // expect all messages are processed
         getThing(2, thingId)
                 .withParam("fields", "_revision")
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .useAwaitility(Awaitility.await()
                         .pollInterval(Duration.ofSeconds(1))
                         .atMost(Duration.ofMinutes(1)))

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/kafka/KafkaConnectivitySuite.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/kafka/KafkaConnectivitySuite.java
@@ -241,7 +241,7 @@ public final class KafkaConnectivitySuite extends
         // expect all messages are processed
         getThing(2, thingId)
                 .withParam("fields", "_revision")
-                .withJWT(testingContextWithRandomNs.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContextWithRandomNs)
                 .useAwaitility(Awaitility.await()
                         .pollInterval(Duration.ofSeconds(1))
                         .atMost(Duration.ofMinutes(1)))

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/logging/ConnectivityLogPublishingIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/logging/ConnectivityLogPublishingIT.java
@@ -72,7 +72,7 @@ import org.eclipse.ditto.testing.common.ServiceEnvironment;
 import org.eclipse.ditto.testing.common.Solution;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.ThingsSubjectIssuer;
-import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.conditions.DockerEnvironment;
 import org.eclipse.ditto.testing.common.conditions.RunIf;
 import org.eclipse.ditto.testing.common.matcher.RestMatcherConfigurer;
@@ -176,15 +176,20 @@ public class ConnectivityLogPublishingIT extends IntegrationTest {
                 .build();
 
         putThingWithPolicy(API_V_2, thing, policy, JsonSchemaVersion.V_2)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
-        configureRestMatchers(testingContext.getOAuthClient());
+        configureRestMatchers();
     }
 
-    private static void configureRestMatchers(final AuthClient authClient) {
-        restMatcherConfigurer = RestMatcherConfigurer.withJwt(authClient.getAccessToken());
+    private static void configureRestMatchers() {
+        final BasicAuth basicAuth = testingContext.getBasicAuth();
+        if (basicAuth.isEnabled()) {
+            restMatcherConfigurer = RestMatcherConfigurer.withBasicAuth(basicAuth);
+        } else {
+            restMatcherConfigurer = RestMatcherConfigurer.withJwt(testingContext.getOAuthClient().getAccessToken());
+        }
         restMatcherFactory = new RestMatcherFactory(restMatcherConfigurer);
     }
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/rest/RestConnectionsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/connectivity/rest/RestConnectionsIT.java
@@ -116,7 +116,7 @@ public final class RestConnectionsIT extends IntegrationTest {
                 .build();
 
         putThingWithPolicy(API_V_2, thing, policy, JsonSchemaVersion.V_2)
-                .withJWT(serviceEnv.getDefaultTestingContext().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getDefaultTestingContext())
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/gateway/GatewayOAuthJWTAuthorizationIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/gateway/GatewayOAuthJWTAuthorizationIT.java
@@ -97,7 +97,7 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
 
         final AuthClient authClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
         final ThingsWebsocketClient thingsWebsocketClient =
-                newTestWebsocketClient(authClient.getAccessToken(), Collections.emptyMap(),
+                newTestWebsocketClient(serviceEnv.getDefaultTestingContext(), Collections.emptyMap(),
                         TestConstants.API_V_2);
 
         thingsWebsocketClient.connect("refreshJwtViaWebSocket-" + UUID.randomUUID());
@@ -119,7 +119,8 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
 
         final String wsJwtToken = authClient.getAccessToken();
         final String restJwtToken = authClient2.getAccessToken();
-        final ThingsWebsocketClient thingsWebsocketClient = newTestWebsocketClient(wsJwtToken, Collections.emptyMap(),
+        final ThingsWebsocketClient thingsWebsocketClient = newTestWebsocketClient(
+                serviceEnv.getDefaultTestingContext(), Collections.emptyMap(),
                 TestConstants.API_V_2, ThingsWebsocketClient.AuthMethod.QUERY_PARAM);
         thingsWebsocketClient.connect("enrichMessagesViaWebSocketWithJwtAsQueryParameter-" + UUID.randomUUID());
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/gateway/GatewayOAuthJWTAuthorizationIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/gateway/GatewayOAuthJWTAuthorizationIT.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.testing.system.gateway;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assume.assumeFalse;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -60,13 +61,12 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
     @Test
     @Category({Acceptance.class})
     public void postThingWithOAuthToken() throws IllegalStateException {
-        final AuthClient authClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
-        final String jwtToken = authClient.getAccessToken();
+        final TestingContext context = serviceEnv.getDefaultTestingContext();
 
         final ThingId thingId = ThingId.of(idGenerator(RANDOM_NAMESPACE).withRandomName());
 
         putThing(TestConstants.API_V_2, Thing.newBuilder().setId(thingId).build(), JsonSchemaVersion.V_2)
-                .withJWT(jwtToken)
+                .withConfiguredAuth(context)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -76,23 +76,25 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
                 Resource.newInstance(PoliciesResourceType.policyResource("/"), readWriteGranted),
                 Resource.newInstance(PoliciesResourceType.thingResource("/"), readWriteGranted));
         final PolicyEntry policyEntry = PoliciesModelFactory.newPolicyEntry(
-                "O-AUTH-CLIENT", Subjects.newInstance(authClient.getSubject()), resources);
+                "O-AUTH-CLIENT", Subjects.newInstance(context.getOAuthClient().getSubject()), resources);
 
         // add permissions user for clean up process
         putPolicyEntry(thingId, policyEntry)
-                .withJWT(jwtToken)
+                .withConfiguredAuth(context)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
         getPolicy(thingId)
-                .withJWT(jwtToken)
+                .withConfiguredAuth(context)
                 .expectingHttpStatus(HttpStatus.OK)
                 .fire();
     }
 
     @Test
-    @Category({Acceptance.class})
+    @Category(Acceptance.class)
     public void refreshJwtViaWebSocket() throws InterruptedException {
+        assumeFalse(serviceEnv.getDefaultTestingContext().getBasicAuth().isEnabled());
+
         final AuthClient authClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
         final ThingsWebsocketClient thingsWebsocketClient =
                 newTestWebsocketClient(authClient.getAccessToken(), Collections.emptyMap(),
@@ -118,7 +120,7 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
         final String wsJwtToken = authClient.getAccessToken();
         final String restJwtToken = authClient2.getAccessToken();
         final ThingsWebsocketClient thingsWebsocketClient = newTestWebsocketClient(wsJwtToken, Collections.emptyMap(),
-                TestConstants.API_V_2, ThingsWebsocketClient.JwtAuthMethod.QUERY_PARAM);
+                TestConstants.API_V_2, ThingsWebsocketClient.AuthMethod.QUERY_PARAM);
         thingsWebsocketClient.connect("enrichMessagesViaWebSocketWithJwtAsQueryParameter-" + UUID.randomUUID());
 
         final List<Adaptable> adaptableList = new CopyOnWriteArrayList<>();
@@ -129,7 +131,8 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
         });
         assertThat(thingsWebsocketClient.isOpen()).isTrue();
         final CompletableFuture<Void> ackConfirmed =
-                thingsWebsocketClient.sendProtocolCommand("START-SEND-EVENTS?namespaces=" + RANDOM_NAMESPACE + "&extraFields=attributes",
+                thingsWebsocketClient.sendProtocolCommand(
+                        "START-SEND-EVENTS?namespaces=" + RANDOM_NAMESPACE + "&extraFields=attributes",
                         "START-SEND-EVENTS:ACK");
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
@@ -139,7 +142,7 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
         final ThingId thingId = ThingId.of(idGenerator(RANDOM_NAMESPACE).withRandomName());
         final Thing thing = new ThingJsonProducer().getThing().toBuilder().setId(thingId).build();
         putThing(TestConstants.API_V_2, thing, JsonSchemaVersion.V_2)
-                .withJWT(restJwtToken)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -148,18 +151,19 @@ public final class GatewayOAuthJWTAuthorizationIT extends IntegrationTest {
         final Resources resources = Resources.newInstance(
                 Resource.newInstance(PoliciesResourceType.policyResource("/"), readWriteGranted),
                 Resource.newInstance(PoliciesResourceType.thingResource("/"), readWriteGranted));
-        final PolicyEntry policyEntry = PoliciesModelFactory.newPolicyEntry(
+        final PolicyEntry policyEntry;
+        policyEntry = PoliciesModelFactory.newPolicyEntry(
                 "O-AUTH-CLIENT", Subjects.newInstance(authClient.getSubject(), authClient2.getSubject()),
                 resources);
 
         putPolicyEntry(thingId, policyEntry)
-                .withJWT(restJwtToken)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire()
                 .print();
 
         patchThing(ThingId.of(thingId), JsonPointer.of("features/Vehicle/properties/status/speed"), JsonValue.of(0))
-                .withJWT(restJwtToken)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire()
                 .print();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/security/AuthorizationV2IT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/security/AuthorizationV2IT.java
@@ -73,8 +73,7 @@ public final class AuthorizationV2IT extends SearchIntegrationTest {
         final Thing thingWithDefaultPermissions = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
                 .build();
-        persistThingAndWaitTillAvailable(thingWithDefaultPermissions, V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+        persistThingAndWaitTillAvailable(thingWithDefaultPermissions, V_2, serviceEnv.getDefaultTestingContext());
 
         // test: USER_2 has no permissions on the thing and thus is not able to see the thing
         final SearchFilter thingIdIsEqual = idFilter(thingId);
@@ -388,7 +387,6 @@ public final class AuthorizationV2IT extends SearchIntegrationTest {
     private static void persistThingWithPolicy(final Thing thing, final Policy policy) {
         final JsonObject thingJson = thing.toJson(V_2, FieldType.notHidden())
                 .setAll(policy.toInlinedJson(V_2, FieldType.notHidden()));
-        persistThingsAndWaitTillAvailable(thingJson.toString(), 1L, V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+        persistThingsAndWaitTillAvailable(thingJson.toString(), 1L, V_2, serviceEnv.getDefaultTestingContext());
     }
 }

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/CountThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/CountThingsIT.java
@@ -51,15 +51,15 @@ public final class CountThingsIT extends VersionedSearchIntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CountThingsIT.class);
 
-    private static final String ATTR1_KEY = "attr1";
-    private static final String ATTR2_KEY = "attr2";
-    private static final String ATTR3_KEY = "attr3";
-    private static final String ATTR4_KEY = "attr4";
+    private static final String ATTR1_KEY = "countThingsIt-attr1";
+    private static final String ATTR2_KEY = "countThingsIt-attr2";
+    private static final String ATTR3_KEY = "countThingsIt-attr3";
+    private static final String ATTR4_KEY = "countThingsIt-attr4";
 
     private static final String THING1_ATTR1_VALUE = "value1_1";
-    private static final int THING1_ATTR2_VALUE = 1234;
+    private static final int THING1_ATTR2_VALUE = 9876;
     private static final boolean THING1_ATTR3_VALUE = true;
-    private static final double THING1_ATTR4_VALUE = 12.987;
+    private static final double THING1_ATTR4_VALUE = 13.163;
 
     private static final String THING2_ATTR1_VALUE = "value2_1";
     private static final String THING2_ATTR2_VALUE = "value2_2";

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsIT.java
@@ -63,10 +63,10 @@ public final class QueryThingsIT {
     @RunWith(Parameterized.class)
     public static final class QueryThingsWithV2 extends VersionedSearchIntegrationTest {
 
-        private static final String ATTR1_KEY = "attr1";
-        private static final String ATTR2_KEY = "attr2";
-        private static final String ATTR3_KEY = "attr3";
-        private static final String ATTR4_KEY = "attr4";
+        private static final String ATTR1_KEY = "queryThingsWithV2It-attr1";
+        private static final String ATTR2_KEY = "queryThingsWithV2It-attr2";
+        private static final String ATTR3_KEY = "queryThingsWithV2It-attr3";
+        private static final String ATTR4_KEY = "queryThingsWithV2It-attr4";
 
         private static final String THING1_ATTR1_VALUE = "value1_1";
         private static final int THING1_ATTR2_VALUE = 1234;

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsIT.java
@@ -24,6 +24,7 @@ import static org.eclipse.ditto.thingsearch.model.SearchModelFactory.newSizeOpti
 import static org.eclipse.ditto.thingsearch.model.SearchModelFactory.newSortOption;
 import static org.eclipse.ditto.thingsearch.model.SearchModelFactory.or;
 import static org.eclipse.ditto.thingsearch.model.SearchModelFactory.property;
+import static org.junit.Assume.assumeFalse;
 
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
@@ -32,10 +33,10 @@ import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.testing.common.IdGenerator;
 import org.eclipse.ditto.testing.common.SearchIntegrationTest;
+import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.Timeout;
 import org.eclipse.ditto.testing.common.VersionedSearchIntegrationTest;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
-import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
 import org.eclipse.ditto.testing.common.matcher.search.SearchMatcher;
 import org.eclipse.ditto.testing.common.matcher.search.SortProperties;
 import org.eclipse.ditto.things.model.Attributes;
@@ -87,10 +88,9 @@ public final class QueryThingsIT {
                     createThingWithRandomAttrValues(createThingId("user1", idGenerator())), 10);
             thing1Id = persistThingAndWaitTillAvailable(createThing1());
             thing2Id = persistThingAndWaitTillAvailable(createThing2());
-            final AuthClient authClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
             persistThingsAndWaitTillAvailable(
                     i -> createThingWithRandomAttrValues(createThingId("user2", idGenerator())),
-                    authClient, 4, V_2);
+                    serviceEnv.getDefaultTestingContext(), 4, V_2);
         }
 
         private static Thing createThingWithRandomAttrValues(final ThingId thingId) {
@@ -224,6 +224,8 @@ public final class QueryThingsIT {
 
         @Test
         public void searchForThingsWithoutPermission() {
+            assumeFalse("Test 'searchForThingsWithoutPermission' skipped due to enabled Basic Auth configuration.",
+                    serviceEnv.getDefaultTestingContext().getBasicAuth().isEnabled());
             unauthorizedSearch(attribute(ATTR1_KEY).eq(THING1_ATTR1_VALUE))
                     .expectingBody(isEmpty())
                     .fire();
@@ -274,10 +276,10 @@ public final class QueryThingsIT {
         private static ThingId thing1Id;
 
         protected void createTestData() {
-            final AuthClient authClient = serviceEnv.getDefaultTestingContext().getOAuthClient();
+            final TestingContext context = serviceEnv.getDefaultTestingContext();
             final Thing thing1 =
                     ThingsModelFactory.newThingBuilder().setId(createThingId("thing1", idGenerator())).build();
-            thing1Id = persistThingAndWaitTillAvailable(thing1, JSON_SCHEMA_VERSION, authClient);
+            thing1Id = persistThingAndWaitTillAvailable(thing1, JSON_SCHEMA_VERSION, context);
         }
 
         @Test

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithFilterByThingDefinitionIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithFilterByThingDefinitionIT.java
@@ -62,13 +62,13 @@ public class QueryThingsWithFilterByThingDefinitionIT extends SearchIntegrationT
 
     protected void createTestData() {
         thing1Id = persistThingAndWaitTillAvailable(createThing1(), JsonSchemaVersion.V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+                serviceEnv.getDefaultTestingContext());
         thing2Id = persistThingAndWaitTillAvailable(createThing2(), JsonSchemaVersion.V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+                serviceEnv.getDefaultTestingContext());
         thing3Id = persistThingAndWaitTillAvailable(createThing3(), JsonSchemaVersion.V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+                serviceEnv.getDefaultTestingContext());
         thing4Id = persistThingAndWaitTillAvailable(createThing4(), JsonSchemaVersion.V_2,
-                serviceEnv.getDefaultTestingContext().getOAuthClient());
+                serviceEnv.getDefaultTestingContext());
     }
 
     private Thing createThing1() {

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/StreamThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/StreamThingsIT.java
@@ -176,7 +176,8 @@ public class StreamThingsIT extends IntegrationTest {
         }
 
         return ThingsWebsocketClient.newInstance(dittoWsUrl(JsonSchemaVersion.V_2.toInt()), authToken,
-                additionalHttpHeaders, proxyServer, ThingsWebsocketClient.JwtAuthMethod.HEADER);
+                serviceEnv.getDefaultTestingContext().getBasicAuth(),
+                additionalHttpHeaders, proxyServer, ThingsWebsocketClient.AuthMethod.HEADER);
     }
 
     @Test

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/MergeIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/MergeIT.java
@@ -498,18 +498,18 @@ public class MergeIT extends IntegrationTest {
                 .append(propertyPath);
 
         patchThing(thingId, Thing.JsonFields.ATTRIBUTES.getPointer().append(attributePath), patchValue)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire();
 
         patchThing(thingId, path, patchValue)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .expectingErrorCode("things:thing.notmodifiable")
                 .fire();
 
         patchThing(thingId, JsonPointer.empty(), JsonFactory.newObject(path, patchValue))
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .expectingErrorCode("things:thing.notmodifiable")
                 .fire();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
@@ -49,6 +49,8 @@ import org.eclipse.ditto.testing.common.TestConstants;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
 import org.eclipse.ditto.testing.common.client.BasicAuth;
+import org.eclipse.ditto.testing.common.config.TestConfig;
+import org.eclipse.ditto.testing.common.config.TestEnvironment;
 import org.eclipse.ditto.testing.common.ws.ThingsWebsocketClient;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingBuilder;
@@ -77,7 +79,9 @@ public final class RequestedAcksIT extends IntegrationTest {
     @BeforeClass
     public static void setUpClients() {
         final Solution solution = ServiceEnvironment.createSolutionWithRandomUsernameRandomNamespace();
-        testingContext = TestingContext.withGeneratedMockClient(solution, TEST_CONFIG);
+        testingContext = TestConfig.getInstance().getTestEnvironment() == TestEnvironment.DEPLOYMENT ?
+                serviceEnv.getDefaultTestingContext() :
+                TestingContext.withGeneratedMockClient(solution, TEST_CONFIG);
 
         ws1Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":custom-ack");
         ws2Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":another-ack");
@@ -97,9 +101,8 @@ public final class RequestedAcksIT extends IntegrationTest {
             headers2.putAll(basicAuthHeader);
         }
 
-        final String accessToken = testingContext.getOAuthClient().getAccessToken();
-        websocketClient1 = newTestWebsocketClient(accessToken, headers1, TestConstants.API_V_2);
-        websocketClient2 = newTestWebsocketClient(accessToken, headers2, TestConstants.API_V_2);
+        websocketClient1 = newTestWebsocketClient(testingContext, headers1, TestConstants.API_V_2);
+        websocketClient2 = newTestWebsocketClient(testingContext, headers2, TestConstants.API_V_2);
 
         websocketClient1.connect("ThingsWebsocketClient-User1-" + UUID.randomUUID());
         websocketClient2.connect("ThingsWebsocketClient-User1-" + UUID.randomUUID());

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
@@ -23,7 +23,6 @@ import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 
 import java.time.Duration;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -86,12 +85,10 @@ public final class RequestedAcksIT extends IntegrationTest {
         ws1Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":custom-ack");
         ws2Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":another-ack");
 
-        final Map<String, String> headers1 = new HashMap<>() {{
-            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack));
-        }};
-        final Map<String, String> headers2 = new HashMap<>() {{
-            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack));
-        }};
+        final Map<String, String> headers1 =
+                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack));
+        final Map<String, String> headers2 =
+                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack));
         final BasicAuth basicAuth = testingContext.getBasicAuth();
         if (basicAuth.isEnabled()) {
             final String credentials = basicAuth.getUsername() + ":" + basicAuth.getPassword();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
@@ -23,6 +23,7 @@ import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -85,10 +86,12 @@ public final class RequestedAcksIT extends IntegrationTest {
         ws1Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":custom-ack");
         ws2Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":another-ack");
 
-        final Map<String, String> headers1 =
-                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack));
-        final Map<String, String> headers2 =
-                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack));
+        final Map<String, String> headers1 = new HashMap<>() {{
+            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack));
+        }};
+        final Map<String, String> headers2 = new HashMap<>() {{
+            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack));
+        }};
         final BasicAuth basicAuth = testingContext.getBasicAuth();
         if (basicAuth.isEnabled()) {
             final String credentials = basicAuth.getUsername() + ":" + basicAuth.getPassword();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/RequestedAcksIT.java
@@ -22,6 +22,8 @@ import static org.eclipse.ditto.base.model.common.HttpStatus.REQUEST_TIMEOUT;
 import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 
 import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,13 +41,14 @@ import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.testing.common.HttpHeader;
 import org.eclipse.ditto.testing.common.IntegrationTest;
 import org.eclipse.ditto.testing.common.ServiceEnvironment;
 import org.eclipse.ditto.testing.common.Solution;
 import org.eclipse.ditto.testing.common.TestConstants;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
-import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.ws.ThingsWebsocketClient;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingBuilder;
@@ -73,20 +76,30 @@ public final class RequestedAcksIT extends IntegrationTest {
 
     @BeforeClass
     public static void setUpClients() {
-        ServiceEnvironment.createSolutionWithRandomUsernameRandomNamespace();
         final Solution solution = ServiceEnvironment.createSolutionWithRandomUsernameRandomNamespace();
         testingContext = TestingContext.withGeneratedMockClient(solution, TEST_CONFIG);
-        final AuthClient client1 = testingContext.getOAuthClient();
 
         ws1Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":custom-ack");
         ws2Ack = AcknowledgementLabel.of(testingContext.getSolution().getUsername() + ":another-ack");
 
-        websocketClient1 = newTestWebsocketClient(client1.getAccessToken(),
-                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack)),
-                TestConstants.API_V_2);
-        websocketClient2 = newTestWebsocketClient(client1.getAccessToken(),
-                Map.of(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack)),
-                TestConstants.API_V_2);
+        final Map<String, String> headers1 = new HashMap<>() {{
+            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws1Ack));
+        }};
+        final Map<String, String> headers2 = new HashMap<>() {{
+            put(DittoHeaderDefinition.DECLARED_ACKS.getKey(), String.format("[\"%s\"]", ws2Ack));
+        }};
+        final BasicAuth basicAuth = testingContext.getBasicAuth();
+        if (basicAuth.isEnabled()) {
+            final String credentials = basicAuth.getUsername() + ":" + basicAuth.getPassword();
+            final Map<String, String> basicAuthHeader = Map.of(
+                    HttpHeader.AUTHORIZATION.getName(), "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes()));
+            headers1.putAll(basicAuthHeader);
+            headers2.putAll(basicAuthHeader);
+        }
+
+        final String accessToken = testingContext.getOAuthClient().getAccessToken();
+        websocketClient1 = newTestWebsocketClient(accessToken, headers1, TestConstants.API_V_2);
+        websocketClient2 = newTestWebsocketClient(accessToken, headers2, TestConstants.API_V_2);
 
         websocketClient1.connect("ThingsWebsocketClient-User1-" + UUID.randomUUID());
         websocketClient2.connect("ThingsWebsocketClient-User1-" + UUID.randomUUID());
@@ -105,7 +118,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingTwinPersistedAcknowledgementAsQueryParam() {
         final Response response = postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withParam(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), DittoAcknowledgementLabel.TWIN_PERSISTED)
                 .expectingHttpStatus(CREATED)
                 .fire();
@@ -113,7 +126,7 @@ public final class RequestedAcksIT extends IntegrationTest {
         final String thingId = parseIdFromLocation(response.header("Location"));
 
         deleteThing(TestConstants.API_V_2, thingId)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withParam(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), DittoAcknowledgementLabel.TWIN_PERSISTED)
                 .expectingHttpStatus(NO_CONTENT)
                 .fire();
@@ -122,7 +135,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingTwinPersistedAcknowledgementAsHeader() {
         final Response response = postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED.toString())
                 .expectingHttpStatus(CREATED)
@@ -131,7 +144,7 @@ public final class RequestedAcksIT extends IntegrationTest {
         final String thingId = parseIdFromLocation(response.header("Location"));
 
         deleteThing(TestConstants.API_V_2, thingId)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED.toString())
                 .expectingHttpStatus(NO_CONTENT)
@@ -141,7 +154,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingEmptyAcknowledgements() {
         postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), "")
                 .expectingHttpStatus(CREATED)
                 .fire();
@@ -150,7 +163,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingEmptyAcknowledgementsAndResponseRequiredFalse() {
         postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), "")
                 .withHeader(DittoHeaderDefinition.RESPONSE_REQUIRED.getKey(), false)
                 .expectingHttpStatus(ACCEPTED)
@@ -160,7 +173,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingUnknownAcknowledgement() {
         postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), "unknown")
                 .withHeader(DittoHeaderDefinition.TIMEOUT.getKey(), "3")
                 .expectingHttpStatus(REQUEST_TIMEOUT) // resulting in 408 timeout
@@ -176,7 +189,7 @@ public final class RequestedAcksIT extends IntegrationTest {
         final String notFulfilledAckLabel = "not-fulfilled";
         final Response response = putThing(TestConstants.API_V_2, Thing.newBuilder().setId(ThingId.of(thingId)).build(),
                 JsonSchemaVersion.V_2)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withParam(DittoHeaderDefinition.CORRELATION_ID.getKey(), correlationId)
                 .withParam(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED + "," + notFulfilledAckLabel)
@@ -222,7 +235,7 @@ public final class RequestedAcksIT extends IntegrationTest {
                 .contains(JsonKey.of(DittoHeaderDefinition.CORRELATION_ID.getKey()), correlationId);
 
         deleteThing(TestConstants.API_V_2, thingId)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withParam(DittoHeaderDefinition.REQUESTED_ACKS.getKey(), DittoAcknowledgementLabel.TWIN_PERSISTED)
                 .expectingHttpStatus(NO_CONTENT)
                 .fire();
@@ -231,7 +244,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingPersistedAcknowledgementWithResponseRequiredFalse() {
         postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED.toString())
                 .withHeader(DittoHeaderDefinition.RESPONSE_REQUIRED.getKey(), "false")
@@ -242,7 +255,7 @@ public final class RequestedAcksIT extends IntegrationTest {
     @Test
     public void createThingRequestingPersistedAcknowledgementWithTimeoutZero() {
         postThing(TestConstants.API_V_2, JsonFactory.newObject())
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withHeader(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED.toString())
                 .withHeader(DittoHeaderDefinition.TIMEOUT.getKey(), "0")
@@ -257,7 +270,7 @@ public final class RequestedAcksIT extends IntegrationTest {
 
         final ThingBuilder.FromScratch thingBuilder = Thing.newBuilder().setId(ThingId.of(thingId));
         putThing(TestConstants.API_V_2, thingBuilder.build(), JsonSchemaVersion.V_2)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .expectingHttpStatus(CREATED)
                 .fire();
 
@@ -301,7 +314,7 @@ public final class RequestedAcksIT extends IntegrationTest {
         final Response updateResponse = putThing(TestConstants.API_V_2, thingBuilder
                         .setAttribute(JsonPointer.of("some"), JsonValue.of(42))
                         .build(), JsonSchemaVersion.V_2)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .withParam(DittoHeaderDefinition.CORRELATION_ID.getKey(), correlationId)
                 .withParam(DittoHeaderDefinition.REQUESTED_ACKS.getKey(),
                         DittoAcknowledgementLabel.TWIN_PERSISTED + "," + ws1Ack + "," + ws2Ack)
@@ -351,7 +364,7 @@ public final class RequestedAcksIT extends IntegrationTest {
                 .contains(JsonKey.of(DittoHeaderDefinition.CORRELATION_ID.getKey()), correlationId);
 
         deleteThing(TestConstants.API_V_2, thingId)
-                .withJWT(testingContext.getOAuthClient().getAccessToken())
+                .withConfiguredAuth(testingContext)
                 .expectingHttpStatus(NO_CONTENT)
                 .fire();
     }

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
@@ -600,13 +600,11 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
-        if (null == basicAuth || !basicAuth.isEnabled()) {
-            // update the Thing with a different solution
-            putThing(TestConstants.API_V_2, thing, JsonSchemaVersion.V_2)
-                    .expectingHttpStatus(HttpStatus.NO_CONTENT)
-                    .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
-                    .fire();
-        }
+        // update the Thing with a different context (in case of OAuth)
+        putThing(TestConstants.API_V_2, thing, JsonSchemaVersion.V_2)
+                .expectingHttpStatus(HttpStatus.NO_CONTENT)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .fire();
     }
 
     @Test

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
@@ -28,12 +28,16 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.testing.common.HttpHeader;
 import org.eclipse.ditto.testing.common.HttpParameter;
 import org.eclipse.ditto.testing.common.HttpResource;
 import org.eclipse.ditto.testing.common.IntegrationTest;
 import org.eclipse.ditto.testing.common.TestConstants;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
+import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
@@ -158,7 +162,7 @@ public final class ThingsIT extends IntegrationTest {
                 .header("Location"));
 
         getThing(TestConstants.API_V_2, thingId)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .fire();
 
@@ -239,7 +243,7 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire();
     }
-    
+
     @Test
     public void getThingsByIdWithFieldSelectors() {
         final List<JsonFieldDefinition<?>> expectedJsonFieldDefinitions = List.of(Thing.JsonFields.ID);
@@ -380,7 +384,7 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire();
     }
-    
+
     @Test
     public void postAndPutSameThing() {
         final ThingId thingId = ThingId.of(parseIdFromLocation(postThing(TestConstants.API_V_2, JsonFactory.newObject())
@@ -398,7 +402,7 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire();
     }
-    
+
     @Test
     public void putThingWithInvalidId() {
         final String thingId = "invalidThingId";
@@ -561,7 +565,7 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.NO_CONTENT)
                 .fire();
     }
-    
+
     @Test
     public void tryToDeleteUnknownThing() {
         deleteThing(TestConstants.API_V_2, serviceEnv.getDefaultNamespaceName() + ":unknownThingId")
@@ -571,13 +575,22 @@ public final class ThingsIT extends IntegrationTest {
 
     @Test
     public void putThingIsAllowedWhenThingAlreadyExists() {
+        final BasicAuth basicAuth = serviceEnv.getDefaultTestingContext().getBasicAuth();
+        final Subjects subjects;
+        if (basicAuth.isEnabled()) {
+            subjects = Subjects.newInstance(Subject.newInstance(
+                    SubjectIssuer.newInstance("nginx"), basicAuth.getUsername()));
+        } else {
+            subjects = Subjects.newInstance(
+                    serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject(),
+                    serviceEnv.getTestingContext2().getOAuthClient().getSubject());
+        }
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
-
         final Thing thing = Thing.newBuilder().setId(thingId).build();
+
         final Policy policy = Policy.newBuilder()
                 .forLabel("DEFAULT")
-                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
-                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getSubject())
+                .setSubjects(subjects)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permission.READ, Permission.WRITE)
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), Permission.READ, Permission.WRITE)
                 .setGrantedPermissions(PoliciesResourceType.messageResource("/"), Permission.READ, Permission.WRITE)
@@ -587,11 +600,13 @@ public final class ThingsIT extends IntegrationTest {
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
-        // update the Thing with a different solution
-        putThing(TestConstants.API_V_2, thing, JsonSchemaVersion.V_2)
-                .expectingHttpStatus(HttpStatus.NO_CONTENT)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
-                .fire();
+        if (null == basicAuth || !basicAuth.isEnabled()) {
+            // update the Thing with a different solution
+            putThing(TestConstants.API_V_2, thing, JsonSchemaVersion.V_2)
+                    .expectingHttpStatus(HttpStatus.NO_CONTENT)
+                    .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                    .fire();
+        }
     }
 
     @Test

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithCopiedPoliciesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithCopiedPoliciesIT.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.testing.system.things.rest;
 
 import static org.eclipse.ditto.policies.api.Permission.READ;
 import static org.eclipse.ditto.policies.api.Permission.WRITE;
+import static org.eclipse.ditto.testing.common.TestConstants.API_V_2;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,9 +34,10 @@ import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.Resource;
 import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.testing.common.HttpHeader;
 import org.eclipse.ditto.testing.common.IntegrationTest;
-import org.eclipse.ditto.testing.common.TestConstants;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
 import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
@@ -90,7 +92,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        postThing(TestConstants.API_V_2, originalThingJson)
+        postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -117,7 +119,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 secondClientForDefaultSolution.getSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2PermissionOnPolicy);
 
-        postThing(TestConstants.API_V_2, originalThingJson)
+        postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -126,7 +128,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 thingWithCopiedPolicyFromId(policyWithUser2PermissionOnPolicy.getEntityId()
                         .orElseThrow(() -> new IllegalStateException("Policy should have an ID")));
 
-        postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        postThing(API_V_2, thingWithCopiedPolicyJson)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .expectingErrorCode("things:thing.notmodifiable")
@@ -141,7 +143,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        postThing(TestConstants.API_V_2, originalThingJson)
+        postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -149,7 +151,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromId(originalPolicy.getEntityId()
                 .orElseThrow(() -> new IllegalStateException("Policy should have an ID")));
 
-        postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        postThing(API_V_2, thingWithCopiedPolicyJson)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("policies:policy.notfound")
@@ -165,7 +167,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final Thing originalThing = parseThingFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final Thing originalThing = parseThingFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -179,6 +181,8 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         getPolicy(copiedPolicyId)
                 .expectingBody(containsOnly(expectedPolicy))
                 .fire();
+        deleteThing(API_V_2, originalThing.getEntityId().get()).fire();
+        deletePolicy(policyId).fire();
     }
     
     @Test
@@ -192,14 +196,14 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                         secondClientForDefaultSolution.getSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2AccessToThing);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
         // create thing with copied policy
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThingId);
 
-        postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        postThing(API_V_2, thingWithCopiedPolicyJson)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("policies:policy.notfound")
@@ -214,7 +218,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final Thing originalThing = parseThingFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final Thing originalThing = parseThingFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -222,7 +226,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThing.getEntityId()
                 .orElseThrow(() -> new IllegalStateException("Thing should have an ID")));
 
-        postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        postThing(API_V_2, thingWithCopiedPolicyJson)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("things:thing.notfound")
@@ -238,7 +242,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -266,7 +270,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 secondClientForDefaultSolution.getSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2PermissionOnPolicy);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -277,7 +281,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                         .orElseThrow(() -> new IllegalStateException("Policy should have an ID")))
                         .set(Thing.JsonFields.ID, newThingId);
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .expectingErrorCode("things:thing.notmodifiable")
@@ -292,7 +296,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -302,7 +306,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 .orElseThrow(() -> new IllegalStateException("Policy should have an ID")))
                 .set(Thing.JsonFields.ID, newThingId);
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("policies:policy.notfound")
@@ -317,7 +321,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final Thing originalThing = parseThingFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final Thing originalThing = parseThingFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -347,7 +351,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                         secondClientForDefaultSolution.getSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2AccessToThing);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -355,7 +359,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThingId)
                 .set(Thing.JsonFields.ID, originalThingId + "_cp");
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("policies:policy.notfound")
@@ -370,7 +374,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -378,7 +382,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThingId)
                 .set(Thing.JsonFields.ID, originalThingId + "_cp");
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .withJWT(secondClientForDefaultSolution.getAccessToken())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .expectingErrorCode("things:thing.notfound")
@@ -393,7 +397,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final Thing originalThing = parseThingFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final Thing originalThing = parseThingFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -425,7 +429,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final Policy originalPolicy = policyWithSpecialLabel(policyId, specialLabel);
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, originalPolicy);
 
-        final Thing originalThing = parseThingFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final Thing originalThing = parseThingFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -451,7 +455,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyAndInlinePolicy = thingWithCopiedPolicyFromId("any:policy")
                 .set(CreateThing.JSON_INLINE_POLICY, JsonObject.newBuilder().build());
 
-        postThing(TestConstants.API_V_2, thingWithCopiedPolicyAndInlinePolicy)
+        postThing(API_V_2, thingWithCopiedPolicyAndInlinePolicy)
                 .expectingHttpStatus(HttpStatus.BAD_REQUEST)
                 .expectingErrorCode("things:policy.conflicting")
                 .fire();
@@ -459,7 +463,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyAndInlinePolicyAndThingId = thingWithCopiedPolicyAndInlinePolicy
                 .set(Thing.JsonFields.ID, idGenerator().withPrefixedRandomName("otherThing"));
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyAndInlinePolicyAndThingId, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyAndInlinePolicyAndThingId, JsonSchemaVersion.V_2)
                 .expectingHttpStatus(HttpStatus.BAD_REQUEST)
                 .expectingErrorCode("things:policy.conflicting")
                 .fire();
@@ -472,7 +476,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 .set(CreateThing.JSON_COPY_POLICY_FROM, invalidRef)
                 .build();
 
-        postThing(TestConstants.API_V_2, thingJson)
+        postThing(API_V_2, thingJson)
                 .expectingHttpStatus(HttpStatus.BAD_REQUEST)
                 .expectingErrorCode("placeholder:placeholder.reference.notsupported")
                 .fire();
@@ -480,7 +484,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingJsonWithId = thingJson
                 .set(Thing.JsonFields.ID, idGenerator().withPrefixedRandomName("otherThing"));
 
-        putThing(TestConstants.API_V_2, thingJsonWithId, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingJsonWithId, JsonSchemaVersion.V_2)
                 .expectingHttpStatus(HttpStatus.BAD_REQUEST)
                 .expectingErrorCode("placeholder:placeholder.reference.notsupported")
                 .fire();
@@ -497,7 +501,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2PermissionOnPolicy);
 
-        final String originalThingId = parseIdFromResponse(postThing(TestConstants.API_V_2, originalThingJson)
+        final String originalThingId = parseIdFromResponse(postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
 
@@ -512,7 +516,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThingId)
                 .set(Thing.JsonFields.ID, originalThingId + "_cp");
 
-        putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .expectingHttpStatus(HttpStatus.FORBIDDEN)
                 .expectingErrorCode("things:thing.notcreatable")
                 .fire();
@@ -531,7 +535,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject());
         final JsonObject originalThingJson = thingWithInlinePolicy(policyId, policyWithUser2PermissionOnPolicy);
 
-        postThing(TestConstants.API_V_2, originalThingJson)
+        postThing(API_V_2, originalThingJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire();
 
@@ -563,7 +567,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromId(originalPolicy.getEntityId()
                 .orElseThrow(() -> new IllegalStateException("Policy should have an ID")));
 
-        return parseThingFromResponse(postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        return parseThingFromResponse(postThing(API_V_2, thingWithCopiedPolicyJson)
                 .withHeader(HttpHeader.ALLOW_POLICY_LOCKOUT, true)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
@@ -582,7 +586,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromId(originalPolicy.getEntityId()
                 .orElseThrow(() -> new IllegalStateException("Policy should have an ID")));
 
-        return parseThingFromResponse(postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        return parseThingFromResponse(postThing(API_V_2, thingWithCopiedPolicyJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
     }
@@ -591,13 +595,13 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         final JsonObject thingWithCopiedPolicyJson = thingWithCopiedPolicyFromThingRef(originalThing.getEntityId()
                 .orElseThrow(() -> new IllegalStateException("Thing should have an ID")));
 
-        return parseThingFromResponse(postThing(TestConstants.API_V_2, thingWithCopiedPolicyJson)
+        return parseThingFromResponse(postThing(API_V_2, thingWithCopiedPolicyJson)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
     }
 
     private static Thing postThingAndExpectCreated(final JsonObject thingToCreate) {
-        return parseThingFromResponse(postThing(TestConstants.API_V_2, thingToCreate)
+        return parseThingFromResponse(postThing(API_V_2, thingToCreate)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
     }
@@ -607,7 +611,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
                 .orElseThrow(() -> new IllegalStateException("Policy should have an ID")))
                 .set(Thing.JsonFields.ID, thingId);
 
-        return parseThingFromResponse(putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        return parseThingFromResponse(putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
     }
@@ -620,7 +624,7 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
     }
 
     private static Thing putThingAndExpectCreated(final JsonObject thingWithCopiedPolicyJson) {
-        return parseThingFromResponse(putThing(TestConstants.API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
+        return parseThingFromResponse(putThing(API_V_2, thingWithCopiedPolicyJson, JsonSchemaVersion.V_2)
                 .expectingHttpStatus(HttpStatus.CREATED)
                 .fire());
     }
@@ -639,9 +643,17 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
     }
 
     private static Policy policyWithSpecialLabel(final PolicyId policyId, final String specialLabel) {
+        final TestingContext context = serviceEnv.getDefaultTestingContext();
+        final Subjects subjects;
+        if (context.getBasicAuth().isEnabled()) {
+            subjects = Subjects.newInstance(Subject.newInstance(
+                    SubjectIssuer.newInstance("nginx"), context.getBasicAuth().getUsername()));
+        } else {
+            subjects = Subjects.newInstance(context.getOAuthClient().getDefaultSubject());
+        }
         return PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel(specialLabel)
-                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getDefaultSubject())
+                .setSubjects(subjects)
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), READ, WRITE)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ, WRITE)
                 .build();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithCopiedPoliciesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithCopiedPoliciesIT.java
@@ -181,8 +181,6 @@ public final class ThingsWithCopiedPoliciesIT extends IntegrationTest {
         getPolicy(copiedPolicyId)
                 .expectingBody(containsOnly(expectedPolicy))
                 .fire();
-        deleteThing(API_V_2, originalThing.getEntityId().get()).fire();
-        deletePolicy(policyId).fire();
     }
     
     @Test

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithImportedPoliciesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithImportedPoliciesIT.java
@@ -62,7 +62,7 @@ public final class ThingsWithImportedPoliciesIT extends IntegrationTest {
                 .fire();
 
         getThing(TestConstants.API_V_2, thingId)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.NOT_FOUND)
                 .fire();
 
@@ -71,7 +71,7 @@ public final class ThingsWithImportedPoliciesIT extends IntegrationTest {
                 .fire();
 
         getThing(TestConstants.API_V_2, thingId)
-                .withJWT(serviceEnv.getTestingContext2().getOAuthClient().getAccessToken())
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(HttpStatus.OK)
                 .fire();
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithPoliciesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsWithPoliciesIT.java
@@ -86,10 +86,12 @@ public final class ThingsWithPoliciesIT extends SearchIntegrationTest {
 
         final JsonObject expectedPolicyJson = createPolicyJson(policyId);
 
-        getPolicy(policyId)
+
+        var res = getPolicy(policyId)
                 .expectingHttpStatus(OK)
                 .expectingBody(contains(expectedPolicyJson))
                 .fire();
+        res.print();
 
         deleteThing(TestConstants.API_V_2, thingId)
                 .expectingHttpStatus(NO_CONTENT)

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/live/LiveHttpChannelMqttAcknowledgementsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/live/LiveHttpChannelMqttAcknowledgementsIT.java
@@ -32,6 +32,7 @@ import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.testing.common.ConnectionsHttpClientResource;
+import org.eclipse.ditto.testing.common.IntegrationTest;
 import org.eclipse.ditto.testing.common.TestSolutionResource;
 import org.eclipse.ditto.testing.common.ThingJsonProducer;
 import org.eclipse.ditto.testing.common.conditions.DockerEnvironment;
@@ -69,7 +70,7 @@ import io.restassured.specification.RequestSpecification;
  * This system test checks the handling of acknowledgements in conjunction with HTTP live requests.
  */
 @RunIf(DockerEnvironment.class)
-public final class LiveHttpChannelMqttAcknowledgementsIT {
+public final class LiveHttpChannelMqttAcknowledgementsIT extends IntegrationTest {
 
     private static final String CONNECTION_NAME = LiveHttpChannelMqttAcknowledgementsIT.class.getSimpleName();
     private static final Duration MQTT_CLIENT_OPERATION_TIMEOUT = Duration.ofSeconds(10L);
@@ -399,7 +400,8 @@ public final class LiveHttpChannelMqttAcknowledgementsIT {
                 .putHeader(DittoHeaderDefinition.DECLARED_ACKS.getKey(), JsonArray.of(webSocketAckLabel).toString())
                 .build();
         final var result =
-                ThingsWebSocketClientFactory.getWebSocketClient(TEST_CONFIG, TEST_SOLUTION_RESOURCE, additionalHeaders);
+                ThingsWebSocketClientFactory.getWebSocketClient(TEST_CONFIG, TEST_SOLUTION_RESOURCE,
+                        serviceEnv.getDefaultTestingContext().getBasicAuth(), additionalHeaders);
         result.connect(testNameCorrelationId.getCorrelationId(".connectWebSocketClient"));
         result.sendProtocolCommand("START-SEND-LIVE-COMMANDS", "START-SEND-LIVE-COMMANDS:ACK").join();
         return result;

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/sse/SseTestDriver.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/sse/SseTestDriver.java
@@ -57,7 +57,7 @@ final class SseTestDriver {
 
         final CompletableFuture<List<SseTestHandler.Message>> future =
                 client.prepareGet(url)
-                        .setHeader("Authorization", "Bearer " + authorization)
+                        .setHeader("Authorization", authorization)
                         .addHeader("Accept", "text/event-stream")
                         .addHeader("Cache-Control", "no-cache")
                         .execute(new SseTestHandler(expectedMessagesCount))

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/StreamPersistedEventsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/StreamPersistedEventsIT.java
@@ -183,7 +183,8 @@ public final class StreamPersistedEventsIT extends IntegrationTest {
         }
 
         return ThingsWebsocketClient.newInstance(dittoWsUrl(JsonSchemaVersion.V_2.toInt()), suiteAuthToken,
-                additionalHttpHeaders, proxyServer, ThingsWebsocketClient.JwtAuthMethod.HEADER);
+                serviceEnv.getDefaultTestingContext().getBasicAuth(),
+                additionalHttpHeaders, proxyServer, ThingsWebsocketClient.AuthMethod.HEADER);
     }
 
     @Test


### PR DESCRIPTION
Acceptance tests now can be configured to run against a deployed Ditto instance.
BasicAuth is also added using configuration.
Instructions added to README.