### PR TITLE
add integration tests for policy import aliases (Ditto issue #2402)

### DIFF
--- a/common/src/main/java/org/eclipse/ditto/testing/common/ResourcePathBuilder.java
+++ b/common/src/main/java/org/eclipse/ditto/testing/common/ResourcePathBuilder.java
@@ -231,6 +231,17 @@ public final class ResourcePathBuilder {
             return this;
         }
 
+        public Policy policyImportsAliases() {
+            stringBuilder.append(SLASH).append("importsAliases");
+            return this;
+        }
+
+        public Policy policyImportsAlias(final CharSequence label) {
+            policyImportsAliases();
+            stringBuilder.append(SLASH).append(checkNotNull(label, "ImportsAlias label"));
+            return this;
+        }
+
         public Policy action(final String label, final String actionName) {
             policyEntries();
             stringBuilder.append(SLASH).append(label);

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithImportsAliasesIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.testing.system.search.things;
+
+import static org.eclipse.ditto.base.model.json.JsonSchemaVersion.V_2;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.policyResource;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.thingResource;
+import static org.eclipse.ditto.testing.common.matcher.search.SearchResponseMatchers.isEmpty;
+import static org.eclipse.ditto.testing.common.matcher.search.SearchResponseMatchers.isEqualTo;
+import static org.eclipse.ditto.things.api.Permission.READ;
+import static org.eclipse.ditto.things.api.Permission.WRITE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.EntriesAdditions;
+import org.eclipse.ditto.policies.model.EntryAddition;
+import org.eclipse.ditto.policies.model.ImportsAlias;
+import org.eclipse.ditto.policies.model.ImportsAliases;
+import org.eclipse.ditto.policies.model.ImportsAliasTarget;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.testing.common.SearchIntegrationTest;
+import org.eclipse.ditto.testing.common.TestingContext;
+import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
+import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.ThingsModelFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Search integration tests verifying that the search index correctly reflects access granted through
+ * policy import aliases. When a subject is added via an alias (which fans out to entries additions targets),
+ * the search index must be updated so that the subject can find the Thing.
+ */
+public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest {
+
+    private static final ConditionFactory AWAITILITY_SEARCH_CONFIG =
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(3, TimeUnit.SECONDS);
+
+    private static final Label ALIAS_LABEL = Label.of("operator");
+    private static final Label TARGET_LABEL_1 = Label.of("operator-reactor");
+    private static final Label TARGET_LABEL_2 = Label.of("operator-turbine");
+
+    private AuthClient secondClient;
+
+    @Before
+    public void setUp() {
+        final TestingContext testingContext =
+                TestingContext.withGeneratedMockClient(serviceEnv.getTestingContext2().getSolution(), TEST_CONFIG);
+        secondClient = testingContext.getOAuthClient();
+    }
+
+    @Test
+    public void thingNotVisibleInSearchBeforeSubjectAddedViaAlias() {
+        // Create Thing with importing policy + alias, but user2 is NOT yet a subject
+        final ThingId thingId = ThingId.of(idGenerator().withRandomName());
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+
+        final Policy templatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(templatePolicy).fire();
+
+        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
+                .build();
+
+        persistThingWithPolicy(thing, thingPolicy);
+
+        // user2 should NOT see the Thing in search
+        searchThings(V_2)
+                .filter(idFilter(thingId))
+                .withJWT(secondClient.getAccessToken())
+                .expectingBody(isEmpty())
+                .fire();
+    }
+
+    @Test
+    public void thingBecomesVisibleInSearchAfterSubjectAddedViaAlias() {
+        final ThingId thingId = ThingId.of(idGenerator().withRandomName());
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+
+        final Policy templatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(templatePolicy).fire();
+
+        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
+                .build();
+
+        persistThingWithPolicy(thing, thingPolicy);
+
+        // Add user2 via the alias — fans out to both entries additions targets
+        final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString(), user2Subject)
+                .fire();
+
+        // user2 should now see the Thing in search (wait for eventual consistency)
+        searchThings(V_2)
+                .useAwaitility(AWAITILITY_SEARCH_CONFIG)
+                .filter(idFilter(thingId))
+                .withJWT(secondClient.getAccessToken())
+                .expectingBody(isEqualTo(toThingResult(thingId)))
+                .fire();
+    }
+
+    @Test
+    public void thingDisappearsFromSearchAfterSubjectRemovedViaAlias() {
+        final ThingId thingId = ThingId.of(idGenerator().withRandomName());
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+
+        final Policy templatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(templatePolicy).fire();
+
+        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
+                .build();
+
+        // Create with user2 already as subject in entries additions
+        final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        final Policy thingPolicyWithUser2 = addUser2ToEntriesAdditions(thingPolicy, tmplPolicyId, user2Subject);
+        persistThingWithPolicy(thing, thingPolicyWithUser2);
+
+        // user2 can see the Thing in search
+        searchThings(V_2)
+                .filter(idFilter(thingId))
+                .withJWT(secondClient.getAccessToken())
+                .expectingBody(isEqualTo(toThingResult(thingId)))
+                .fire();
+
+        // Remove user2 via the alias
+        deletePolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString())
+                .fire();
+
+        // user2 should no longer see the Thing (wait for eventual consistency)
+        searchThings(V_2)
+                .useAwaitility(AWAITILITY_SEARCH_CONFIG)
+                .filter(idFilter(thingId))
+                .withJWT(secondClient.getAccessToken())
+                .expectingBody(isEmpty())
+                .fire();
+    }
+
+    // --- Helpers ---
+
+    private static Policy buildTemplatePolicy(final PolicyId templateId) {
+        return PoliciesModelFactory.newPolicyBuilder(templateId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel(TARGET_LABEL_1.toString())
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .forLabel(TARGET_LABEL_2.toString())
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .build();
+    }
+
+    private static Policy buildImportingPolicyWithAlias(final PolicyId policyId, final PolicyId tmplPolicyId) {
+        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1, null, null);
+        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2, null, null);
+        final EntriesAdditions entriesAdditions =
+                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
+        final PolicyImport pImport = PoliciesModelFactory.newPolicyImport(tmplPolicyId, effectedImports);
+
+        final List<ImportsAliasTarget> targets = Arrays.asList(
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_1),
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_2));
+        final ImportsAlias alias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
+
+        return PoliciesModelFactory.newPolicyBuilder(policyId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(pImport)))
+                .setImportsAliases(PoliciesModelFactory.newImportsAliases(Collections.singletonList(alias)))
+                .build();
+    }
+
+    private static Policy addUser2ToEntriesAdditions(final Policy policy, final PolicyId tmplPolicyId,
+            final Subject user2Subject) {
+        // Rebuild the policy with user2 already in entries additions
+        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1,
+                org.eclipse.ditto.policies.model.Subjects.newInstance(user2Subject), null);
+        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2,
+                org.eclipse.ditto.policies.model.Subjects.newInstance(user2Subject), null);
+        final EntriesAdditions entriesAdditions =
+                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
+        final PolicyImport pImport = PoliciesModelFactory.newPolicyImport(tmplPolicyId, effectedImports);
+
+        final List<ImportsAliasTarget> targets = Arrays.asList(
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_1),
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_2));
+        final ImportsAlias alias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
+
+        return policy.toBuilder()
+                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(pImport)))
+                .setImportsAliases(PoliciesModelFactory.newImportsAliases(Collections.singletonList(alias)))
+                .build();
+    }
+
+    private static Subject defaultSubject() {
+        return serviceEnv.getDefaultTestingContext().getOAuthClient().getDefaultSubject();
+    }
+
+    private static void persistThingWithPolicy(final Thing thing, final Policy policy) {
+        final JsonObject thingJson = thing.toJson(V_2, FieldType.notHidden())
+                .setAll(policy.toInlinedJson(V_2, FieldType.notHidden()));
+        persistThingsAndWaitTillAvailable(thingJson.toString(), 1L, V_2, serviceEnv.getDefaultTestingContext());
+    }
+
+}

--- a/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/search/things/QueryThingsWithImportsAliasesIT.java
@@ -23,13 +23,13 @@ import static org.eclipse.ditto.things.api.Permission.WRITE;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
-import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.policies.model.AllowedImportAddition;
 import org.eclipse.ditto.policies.model.EffectedImports;
 import org.eclipse.ditto.policies.model.EntriesAdditions;
 import org.eclipse.ditto.policies.model.EntryAddition;
@@ -43,6 +43,7 @@ import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
 import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.testing.common.SearchIntegrationTest;
 import org.eclipse.ditto.testing.common.TestingContext;
 import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
@@ -77,23 +78,21 @@ public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest
 
     @Test
     public void thingNotVisibleInSearchBeforeSubjectAddedViaAlias() {
-        // Create Thing with importing policy + alias, but user2 is NOT yet a subject
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
         final PolicyId thingPolicyId = PolicyId.of(thingId);
 
-        final Policy templatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(templatePolicy).fire();
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        putPolicy(buildTemplatePolicy(tmplPolicyId)).fire();
 
-        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
         final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).fire();
 
         final Thing thing = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
+                .setPolicyId(thingPolicyId)
                 .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
                 .build();
-
-        persistThingWithPolicy(thing, thingPolicy);
+        persistThingAndWaitTillAvailable(thing, V_2, serviceEnv.getDefaultTestingContext());
 
         // user2 should NOT see the Thing in search
         searchThings(V_2)
@@ -108,19 +107,18 @@ public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
         final PolicyId thingPolicyId = PolicyId.of(thingId);
 
-        final Policy templatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(templatePolicy).fire();
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        putPolicy(buildTemplatePolicy(tmplPolicyId)).fire();
 
-        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
         final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).fire();
 
         final Thing thing = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
+                .setPolicyId(thingPolicyId)
                 .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
                 .build();
-
-        persistThingWithPolicy(thing, thingPolicy);
+        persistThingAndWaitTillAvailable(thing, V_2, serviceEnv.getDefaultTestingContext());
 
         // Add user2 via the alias — fans out to both entries additions targets
         final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
@@ -142,25 +140,29 @@ public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
         final PolicyId thingPolicyId = PolicyId.of(thingId);
 
-        final Policy templatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(templatePolicy).fire();
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        putPolicy(buildTemplatePolicy(tmplPolicyId)).fire();
 
-        final PolicyId tmplPolicyId = templatePolicy.getEntityId().orElseThrow();
+        // Create importing policy and then add user2 via alias (instead of embedding in entriesAdditions)
         final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).fire();
 
         final Thing thing = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
+                .setPolicyId(thingPolicyId)
                 .setAttribute(JsonFactory.newPointer("status"), JsonFactory.newValue("active"))
                 .build();
+        persistThingAndWaitTillAvailable(thing, V_2, serviceEnv.getDefaultTestingContext());
 
-        // Create with user2 already as subject in entries additions
+        // Add user2 via alias
         final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
-        final Policy thingPolicyWithUser2 = addUser2ToEntriesAdditions(thingPolicy, tmplPolicyId, user2Subject);
-        persistThingWithPolicy(thing, thingPolicyWithUser2);
+        putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString(), user2Subject)
+                .fire();
 
-        // user2 can see the Thing in search
+        // user2 can see the Thing in search (wait for eventual consistency)
         searchThings(V_2)
+                .useAwaitility(AWAITILITY_SEARCH_CONFIG)
                 .filter(idFilter(thingId))
                 .withJWT(secondClient.getAccessToken())
                 .expectingBody(isEqualTo(toThingResult(thingId)))
@@ -192,10 +194,12 @@ public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor(TARGET_LABEL_1.toString(), Set.of(AllowedImportAddition.SUBJECTS))
                 .forLabel(TARGET_LABEL_2.toString())
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor(TARGET_LABEL_2.toString(), Set.of(AllowedImportAddition.SUBJECTS))
                 .build();
     }
 
@@ -223,38 +227,8 @@ public final class QueryThingsWithImportsAliasesIT extends SearchIntegrationTest
                 .build();
     }
 
-    private static Policy addUser2ToEntriesAdditions(final Policy policy, final PolicyId tmplPolicyId,
-            final Subject user2Subject) {
-        // Rebuild the policy with user2 already in entries additions
-        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1,
-                org.eclipse.ditto.policies.model.Subjects.newInstance(user2Subject), null);
-        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2,
-                org.eclipse.ditto.policies.model.Subjects.newInstance(user2Subject), null);
-        final EntriesAdditions entriesAdditions =
-                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
-        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
-                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
-        final PolicyImport pImport = PoliciesModelFactory.newPolicyImport(tmplPolicyId, effectedImports);
-
-        final List<ImportsAliasTarget> targets = Arrays.asList(
-                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_1),
-                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_2));
-        final ImportsAlias alias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
-
-        return policy.toBuilder()
-                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(pImport)))
-                .setImportsAliases(PoliciesModelFactory.newImportsAliases(Collections.singletonList(alias)))
-                .build();
-    }
-
     private static Subject defaultSubject() {
         return serviceEnv.getDefaultTestingContext().getOAuthClient().getDefaultSubject();
-    }
-
-    private static void persistThingWithPolicy(final Thing thing, final Policy policy) {
-        final JsonObject thingJson = thing.toJson(V_2, FieldType.notHidden())
-                .setAll(policy.toInlinedJson(V_2, FieldType.notHidden()));
-        persistThingsAndWaitTillAvailable(thingJson.toString(), 1L, V_2, serviceEnv.getDefaultTestingContext());
     }
 
 }

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
@@ -12,9 +12,8 @@
  */
 package org.eclipse.ditto.testing.system.things.rest;
 
-import static org.eclipse.ditto.base.model.common.HttpStatus.BAD_REQUEST;
-import static org.eclipse.ditto.base.model.common.HttpStatus.CONFLICT;
 import static org.eclipse.ditto.base.model.common.HttpStatus.CREATED;
+import static org.eclipse.ditto.base.model.common.HttpStatus.FORBIDDEN;
 import static org.eclipse.ditto.base.model.common.HttpStatus.NOT_FOUND;
 import static org.eclipse.ditto.base.model.common.HttpStatus.NO_CONTENT;
 import static org.eclipse.ditto.base.model.common.HttpStatus.OK;
@@ -26,12 +25,13 @@ import static org.eclipse.ditto.things.api.Permission.WRITE;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
+import java.util.Set;
 
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.AllowedImportAddition;
 import org.eclipse.ditto.policies.model.EffectedImports;
 import org.eclipse.ditto.policies.model.EntriesAdditions;
 import org.eclipse.ditto.policies.model.EntryAddition;
@@ -43,9 +43,7 @@ import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.PolicyImport;
-import org.eclipse.ditto.policies.model.PolicyImports;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.testing.common.IntegrationTest;
@@ -91,10 +89,12 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor("operator-reactor", Set.of(AllowedImportAddition.SUBJECTS))
                 .forLabel("operator-turbine")
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor("operator-turbine", Set.of(AllowedImportAddition.SUBJECTS))
                 .build();
 
         // Build the alias and its targets
@@ -321,15 +321,25 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
     public void aliasLabelConflictsWithLocalEntry() {
         putPolicy(templatePolicyId, templatePolicy).expectingHttpStatus(CREATED).fire();
 
-        // Create a policy with a local entry called "operator" (same as alias label)
-        final Policy policyWithConflict = importingPolicy.toBuilder()
-                .forLabel("operator")
-                .setSubject(defaultSubject())
-                .setGrantedPermissions(thingResource("/"), READ)
+        // Build conflicting policy as raw JSON to bypass client-side model validation
+        // (the PolicyBuilder throws ImportsAliasConflictException locally)
+        final JsonObject operatorEntry = JsonObject.newBuilder()
+                .set("subjects", JsonObject.newBuilder()
+                        .set(defaultSubject().getId().toString(), defaultSubject().toJson())
+                        .build())
+                .set("resources", JsonObject.newBuilder()
+                        .set("thing:/", JsonObject.newBuilder()
+                                .set("grant", JsonValue.of("[\"READ\"]"))
+                                .set("revoke", JsonValue.of("[]"))
+                                .build())
+                        .build())
+                .build();
+        final JsonObject conflictingPolicyJson = importingPolicy.toJson().toBuilder()
+                .set(JsonPointer.of("entries/operator"), operatorEntry)
                 .build();
 
-        putPolicy(importingPolicyId, policyWithConflict)
-                .expectingHttpStatus(CONFLICT)
+        putPolicy(importingPolicyId, conflictingPolicyJson)
+                .expectingHttpStatus(HttpStatus.CONFLICT)
                 .fire();
     }
 
@@ -337,9 +347,9 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
     public void deleteImportReferencedByAliasIsRejected() {
         createTemplateThenImportingPolicy();
 
-        // Attempt to delete the import that is referenced by the alias
+        // Server returns 403 (policies:import.notmodifiable) when alias references the import
         deletePolicyImport(importingPolicyId, templatePolicyId)
-                .expectingHttpStatus(CONFLICT)
+                .expectingHttpStatus(FORBIDDEN)
                 .fire();
     }
 
@@ -362,9 +372,9 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
     public void resourceOperationsOnAliasLabelAreRejected() {
         createTemplateThenImportingPolicy();
 
-        // Attempting to GET resources on an alias label should be rejected
+        // Alias labels are not real entries — server returns 404 for non-subject operations
         getPolicyEntryResources(importingPolicyId, ALIAS_LABEL.toString())
-                .expectingHttpStatus(BAD_REQUEST)
+                .expectingHttpStatus(NOT_FOUND)
                 .fire();
     }
 
@@ -372,40 +382,41 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
 
     @Test
     public void subjectAddedViaAliasGainsAccessToThing() {
-        // Create a Thing whose policy imports the template and defines an alias
         final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasEnforcement"));
+
+        // Create template and importing policy separately (putThingWithPolicy strips imports/aliases)
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        final Policy tmplPolicy = buildTemplatePolicy(tmplPolicyId);
+        putPolicy(tmplPolicy).expectingHttpStatus(CREATED).fire();
+
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).expectingHttpStatus(CREATED).fire();
+
+        // Create the Thing referencing the existing policy
         final Thing thing = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
+                .setPolicyId(thingPolicyId)
                 .setAttribute(JsonPointer.of("status"), JsonValue.of("active"))
                 .build();
-
-        // Build the importing policy with the Thing's ID as policy ID
-        final PolicyId thingPolicyId = PolicyId.of(thingId);
-        final Policy thingTemplatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
-
-        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
-        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
-
-        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+        putThing(TestConstants.API_V_2, thing, org.eclipse.ditto.base.model.json.JsonSchemaVersion.V_2)
                 .expectingHttpStatus(CREATED)
                 .fire();
 
-        // user2 cannot access the Thing yet (not in any policy entry)
+        // user2 cannot access the Thing yet
         getThing(TestConstants.API_V_2, thingId)
                 .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(NOT_FOUND)
                 .fire();
 
-        // Add user2 as subject through the alias — fans out to both entries additions targets
+        // Add user2 as subject through the alias
         final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
         putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
                 user2Subject.getId().toString(), user2Subject)
                 .expectingHttpStatus(CREATED)
                 .fire();
 
-        // user2 can now access the Thing (subject was added to entries additions which grant thing:/ READ)
+        // user2 can now access the Thing
         getThing(TestConstants.API_V_2, thingId)
                 .withConfiguredAuth(serviceEnv.getTestingContext2())
                 .expectingHttpStatus(OK)
@@ -415,20 +426,21 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
     @Test
     public void subjectRemovedViaAliasLosesAccessToThing() {
         final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasRevoke"));
-        final Thing thing = ThingsModelFactory.newThingBuilder()
-                .setId(thingId)
-                .setAttribute(JsonPointer.of("status"), JsonValue.of("active"))
-                .build();
+
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        final Policy tmplPolicy = buildTemplatePolicy(tmplPolicyId);
+        putPolicy(tmplPolicy).expectingHttpStatus(CREATED).fire();
 
         final PolicyId thingPolicyId = PolicyId.of(thingId);
-        final Policy thingTemplatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
-
-        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
         final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).expectingHttpStatus(CREATED).fire();
 
-        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setPolicyId(thingPolicyId)
+                .setAttribute(JsonPointer.of("status"), JsonValue.of("active"))
+                .build();
+        putThing(TestConstants.API_V_2, thing, org.eclipse.ditto.base.model.json.JsonSchemaVersion.V_2)
                 .expectingHttpStatus(CREATED)
                 .fire();
 
@@ -461,20 +473,21 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
     @Test
     public void subjectAddedViaAliasCanWriteThingWhenEntriesGrantWrite() {
         final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasWrite"));
-        final Thing thing = ThingsModelFactory.newThingBuilder()
-                .setId(thingId)
-                .setAttribute(JsonPointer.of("counter"), JsonValue.of(0))
-                .build();
+
+        final PolicyId tmplPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("tmpl"));
+        final Policy tmplPolicy = buildTemplatePolicy(tmplPolicyId);
+        putPolicy(tmplPolicy).expectingHttpStatus(CREATED).fire();
 
         final PolicyId thingPolicyId = PolicyId.of(thingId);
-        final Policy thingTemplatePolicy = buildTemplatePolicy(
-                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
-        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
-
-        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
         final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+        putPolicy(thingPolicy).expectingHttpStatus(CREATED).fire();
 
-        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setPolicyId(thingPolicyId)
+                .setAttribute(JsonPointer.of("counter"), JsonValue.of(0))
+                .build();
+        putThing(TestConstants.API_V_2, thing, org.eclipse.ditto.base.model.json.JsonSchemaVersion.V_2)
                 .expectingHttpStatus(CREATED)
                 .fire();
 
@@ -512,10 +525,12 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor(TARGET_LABEL_1.toString(), Set.of(AllowedImportAddition.SUBJECTS))
                 .forLabel(TARGET_LABEL_2.toString())
                 .setSubject(defaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor(TARGET_LABEL_2.toString(), Set.of(AllowedImportAddition.SUBJECTS))
                 .build();
     }
 

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -329,8 +331,8 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
                         .build())
                 .set("resources", JsonObject.newBuilder()
                         .set("thing:/", JsonObject.newBuilder()
-                                .set("grant", JsonValue.of("[\"READ\"]"))
-                                .set("revoke", JsonValue.of("[]"))
+                                .set("grant", JsonArray.of("READ"))
+                                .set("revoke", JsonFactory.newArray())
                                 .build())
                         .build())
                 .build();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.testing.system.things.rest;
+
+import static org.eclipse.ditto.base.model.common.HttpStatus.BAD_REQUEST;
+import static org.eclipse.ditto.base.model.common.HttpStatus.CONFLICT;
+import static org.eclipse.ditto.base.model.common.HttpStatus.CREATED;
+import static org.eclipse.ditto.base.model.common.HttpStatus.NOT_FOUND;
+import static org.eclipse.ditto.base.model.common.HttpStatus.NO_CONTENT;
+import static org.eclipse.ditto.base.model.common.HttpStatus.OK;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.policyResource;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.thingResource;
+import static org.eclipse.ditto.things.api.Permission.READ;
+import static org.eclipse.ditto.things.api.Permission.WRITE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.EntriesAdditions;
+import org.eclipse.ditto.policies.model.EntryAddition;
+import org.eclipse.ditto.policies.model.ImportsAlias;
+import org.eclipse.ditto.policies.model.ImportsAliases;
+import org.eclipse.ditto.policies.model.ImportsAliasTarget;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.PolicyImports;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.Subjects;
+import org.eclipse.ditto.testing.common.IntegrationTest;
+import org.eclipse.ditto.testing.common.ResourcePathBuilder;
+import org.eclipse.ditto.testing.common.TestConstants;
+import org.eclipse.ditto.testing.common.matcher.DeleteMatcher;
+import org.eclipse.ditto.testing.common.matcher.GetMatcher;
+import org.eclipse.ditto.testing.common.matcher.PutMatcher;
+import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.ThingsModelFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@code /policies/<policyId>/importsAliases} resources and subject fan-out through alias labels.
+ */
+public final class PolicyImportsAliasesIT extends IntegrationTest {
+
+    private static final Label ALIAS_LABEL = Label.of("operator");
+    private static final Label TARGET_LABEL_1 = Label.of("operator-reactor");
+    private static final Label TARGET_LABEL_2 = Label.of("operator-turbine");
+
+    private PolicyId templatePolicyId;
+    private PolicyId importingPolicyId;
+    private Policy templatePolicy;
+    private Policy importingPolicy;
+    private ImportsAlias alias;
+    private ImportsAliases aliases;
+
+    @Before
+    public void setUp() {
+        templatePolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("template"));
+        importingPolicyId = PolicyId.of(idGenerator().withPrefixedRandomName("importing"));
+
+        // Template policy: provides entries that can be imported with entriesAdditions
+        templatePolicy = PoliciesModelFactory.newPolicyBuilder(templatePolicyId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel("operator-reactor")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .forLabel("operator-turbine")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .build();
+
+        // Build the alias and its targets
+        final List<ImportsAliasTarget> targets = Arrays.asList(
+                PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1),
+                PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_2)
+        );
+        alias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
+        aliases = PoliciesModelFactory.newImportsAliases(Collections.singletonList(alias));
+
+        // Build the import with entriesAdditions for both target entries
+        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1, null, null);
+        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2, null, null);
+        final EntriesAdditions entriesAdditions =
+                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
+        final PolicyImport policyImport = PoliciesModelFactory.newPolicyImport(templatePolicyId, effectedImports);
+
+        // Importing policy: has admin entry, imports template, defines alias
+        importingPolicy = PoliciesModelFactory.newPolicyBuilder(importingPolicyId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(policyImport)))
+                .setImportsAliases(aliases)
+                .build();
+    }
+
+    // --- CRUD on /importsAliases ---
+
+    @Test
+    public void createPolicyWithImportsAliasesAndRetrieveThem() {
+        createTemplateThenImportingPolicy();
+
+        getImportsAliases(importingPolicyId)
+                .expectingBody(containsOnly(aliases.toJson()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void retrieveSingleImportsAlias() {
+        createTemplateThenImportingPolicy();
+
+        getImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingBody(containsOnly(alias.toJson()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void putAndGetSingleImportsAlias() {
+        // Create policies without alias first
+        putPolicy(templatePolicyId, templatePolicy).expectingHttpStatus(CREATED).fire();
+        final Policy policyWithoutAlias = importingPolicy.toBuilder()
+                .setImportsAliases(PoliciesModelFactory.emptyImportsAliases())
+                .build();
+        putPolicy(importingPolicyId, policyWithoutAlias).expectingHttpStatus(CREATED).fire();
+
+        // PUT a single alias
+        putImportsAlias(importingPolicyId, ALIAS_LABEL, alias.toJson())
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // GET it back
+        getImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingBody(containsOnly(alias.toJson()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void modifyExistingImportsAlias() {
+        createTemplateThenImportingPolicy();
+
+        // Modify alias to only have one target
+        final ImportsAlias modifiedAlias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL,
+                Collections.singletonList(
+                        PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1)));
+
+        putImportsAlias(importingPolicyId, ALIAS_LABEL, modifiedAlias.toJson())
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        getImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingBody(containsOnly(modifiedAlias.toJson()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void deleteSingleImportsAlias() {
+        createTemplateThenImportingPolicy();
+
+        deleteImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        getImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingHttpStatus(NOT_FOUND)
+                .fire();
+    }
+
+    @Test
+    public void deleteAllImportsAliases() {
+        createTemplateThenImportingPolicy();
+
+        deleteImportsAliases(importingPolicyId)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        getImportsAliases(importingPolicyId)
+                .expectingBody(containsOnly(JsonObject.empty()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void putAllImportsAliases() {
+        createTemplateThenImportingPolicy();
+
+        // Replace all aliases with a different alias
+        final Label newAliasLabel = Label.of("inspector");
+        final ImportsAlias newAlias = PoliciesModelFactory.newImportsAlias(newAliasLabel,
+                Collections.singletonList(
+                        PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1)));
+        final ImportsAliases newAliases = PoliciesModelFactory.newImportsAliases(Collections.singletonList(newAlias));
+
+        putImportsAliases(importingPolicyId, newAliases)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        getImportsAliases(importingPolicyId)
+                .expectingBody(containsOnly(newAliases.toJson()))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void getNonExistentImportsAliasReturns404() {
+        createTemplateThenImportingPolicy();
+
+        // Delete the alias first
+        deleteImportsAlias(importingPolicyId, ALIAS_LABEL).expectingHttpStatus(NO_CONTENT).fire();
+
+        getImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingHttpStatus(NOT_FOUND)
+                .fire();
+    }
+
+    // --- Subject fan-out through alias ---
+
+    @Test
+    public void putSubjectsThroughAliasFansOutToAllTargets() {
+        createTemplateThenImportingPolicy();
+
+        final Subject newSubject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        final Subjects subjects = Subjects.newInstance(newSubject);
+
+        // PUT subjects via the alias label (uses the entries/{label}/subjects endpoint)
+        putPolicyEntrySubjects(importingPolicyId, ALIAS_LABEL.toString(), subjects)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        // Verify subject was added — retrieving via alias returns subjects from first target
+        getPolicyEntrySubjects(importingPolicyId, ALIAS_LABEL.toString())
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void putSingleSubjectThroughAlias() {
+        createTemplateThenImportingPolicy();
+
+        final Subject newSubject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        final String subjectId = newSubject.getId().toString();
+
+        putPolicyEntrySubject(importingPolicyId, ALIAS_LABEL.toString(), subjectId, newSubject)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        getPolicyEntrySubject(importingPolicyId, ALIAS_LABEL.toString(), subjectId)
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void deleteSingleSubjectThroughAlias() {
+        createTemplateThenImportingPolicy();
+
+        final Subject newSubject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        final String subjectId = newSubject.getId().toString();
+
+        // First add a subject
+        putPolicyEntrySubject(importingPolicyId, ALIAS_LABEL.toString(), subjectId, newSubject)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // Then delete it via alias
+        deletePolicyEntrySubject(importingPolicyId, ALIAS_LABEL.toString(), subjectId)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        // Verify it's gone
+        getPolicyEntrySubject(importingPolicyId, ALIAS_LABEL.toString(), subjectId)
+                .expectingHttpStatus(NOT_FOUND)
+                .fire();
+    }
+
+    @Test
+    public void retrieveSubjectsThroughAlias() {
+        createTemplateThenImportingPolicy();
+
+        getPolicyEntrySubjects(importingPolicyId, ALIAS_LABEL.toString())
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    // --- Conflict and protection scenarios ---
+
+    @Test
+    public void aliasLabelConflictsWithLocalEntry() {
+        putPolicy(templatePolicyId, templatePolicy).expectingHttpStatus(CREATED).fire();
+
+        // Create a policy with a local entry called "operator" (same as alias label)
+        final Policy policyWithConflict = importingPolicy.toBuilder()
+                .forLabel("operator")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ)
+                .build();
+
+        putPolicy(importingPolicyId, policyWithConflict)
+                .expectingHttpStatus(CONFLICT)
+                .fire();
+    }
+
+    @Test
+    public void deleteImportReferencedByAliasIsRejected() {
+        createTemplateThenImportingPolicy();
+
+        // Attempt to delete the import that is referenced by the alias
+        deletePolicyImport(importingPolicyId, templatePolicyId)
+                .expectingHttpStatus(CONFLICT)
+                .fire();
+    }
+
+    @Test
+    public void deleteImportSucceedsAfterRemovingAlias() {
+        createTemplateThenImportingPolicy();
+
+        // First remove the alias
+        deleteImportsAlias(importingPolicyId, ALIAS_LABEL)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        // Now deleting the import should succeed
+        deletePolicyImport(importingPolicyId, templatePolicyId)
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+    }
+
+    @Test
+    public void resourceOperationsOnAliasLabelAreRejected() {
+        createTemplateThenImportingPolicy();
+
+        // Attempting to GET resources on an alias label should be rejected
+        getPolicyEntryResources(importingPolicyId, ALIAS_LABEL.toString())
+                .expectingHttpStatus(BAD_REQUEST)
+                .fire();
+    }
+
+    // --- Policy enforcement through alias ---
+
+    @Test
+    public void subjectAddedViaAliasGainsAccessToThing() {
+        // Create a Thing whose policy imports the template and defines an alias
+        final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasEnforcement"));
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonPointer.of("status"), JsonValue.of("active"))
+                .build();
+
+        // Build the importing policy with the Thing's ID as policy ID
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+        final Policy thingTemplatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
+
+        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // user2 cannot access the Thing yet (not in any policy entry)
+        getThing(TestConstants.API_V_2, thingId)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .expectingHttpStatus(NOT_FOUND)
+                .fire();
+
+        // Add user2 as subject through the alias — fans out to both entries additions targets
+        final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString(), user2Subject)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // user2 can now access the Thing (subject was added to entries additions which grant thing:/ READ)
+        getThing(TestConstants.API_V_2, thingId)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    @Test
+    public void subjectRemovedViaAliasLosesAccessToThing() {
+        final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasRevoke"));
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonPointer.of("status"), JsonValue.of("active"))
+                .build();
+
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+        final Policy thingTemplatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
+
+        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // Add user2 via alias
+        final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString(), user2Subject)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // Verify user2 has access
+        getThing(TestConstants.API_V_2, thingId)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .expectingHttpStatus(OK)
+                .fire();
+
+        // Remove user2 via alias
+        deletePolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString())
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        // user2 can no longer access the Thing
+        getThing(TestConstants.API_V_2, thingId)
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .expectingHttpStatus(NOT_FOUND)
+                .fire();
+    }
+
+    @Test
+    public void subjectAddedViaAliasCanWriteThingWhenEntriesGrantWrite() {
+        final ThingId thingId = ThingId.of(idGenerator().withPrefixedRandomName("aliasWrite"));
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(thingId)
+                .setAttribute(JsonPointer.of("counter"), JsonValue.of(0))
+                .build();
+
+        final PolicyId thingPolicyId = PolicyId.of(thingId);
+        final Policy thingTemplatePolicy = buildTemplatePolicy(
+                PolicyId.of(idGenerator().withPrefixedRandomName("tmpl")));
+        putPolicy(thingTemplatePolicy).expectingHttpStatus(CREATED).fire();
+
+        final PolicyId tmplPolicyId = thingTemplatePolicy.getEntityId().orElseThrow();
+        final Policy thingPolicy = buildImportingPolicyWithAlias(thingPolicyId, tmplPolicyId);
+
+        putThingWithPolicy(TestConstants.API_V_2, thing, thingPolicy, JsonSchemaVersion.V_2)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // Add user2 via alias (template entries grant READ+WRITE on thing:/)
+        final Subject user2Subject = serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject();
+        putPolicyEntrySubject(thingPolicyId, ALIAS_LABEL.toString(),
+                user2Subject.getId().toString(), user2Subject)
+                .expectingHttpStatus(CREATED)
+                .fire();
+
+        // user2 can now write to the Thing's attributes
+        final String attributePath = ResourcePathBuilder.forThing(thingId).attribute("counter").toString();
+        put(dittoUrl(TestConstants.API_V_2, attributePath), "42")
+                .withConfiguredAuth(serviceEnv.getTestingContext2())
+                .expectingHttpStatus(NO_CONTENT)
+                .fire();
+
+        // Verify the write took effect by reading the attribute
+        final String getAttrPath = ResourcePathBuilder.forThing(thingId).attribute("counter").toString();
+        get(dittoUrl(TestConstants.API_V_2, getAttrPath))
+                .expectingBody(containsCharSequence("42"))
+                .expectingHttpStatus(OK)
+                .fire();
+    }
+
+    // --- Helpers ---
+
+    private Policy buildTemplatePolicy(final PolicyId templateId) {
+        return PoliciesModelFactory.newPolicyBuilder(templateId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel(TARGET_LABEL_1.toString())
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .forLabel(TARGET_LABEL_2.toString())
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .build();
+    }
+
+    private Policy buildImportingPolicyWithAlias(final PolicyId policyId, final PolicyId tmplPolicyId) {
+        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1, null, null);
+        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2, null, null);
+        final EntriesAdditions entriesAdditions =
+                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
+        final PolicyImport pImport = PoliciesModelFactory.newPolicyImport(tmplPolicyId, effectedImports);
+
+        final List<ImportsAliasTarget> targets = Arrays.asList(
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_1),
+                PoliciesModelFactory.newImportsAliasTarget(tmplPolicyId, TARGET_LABEL_2));
+        final ImportsAlias a = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
+
+        return PoliciesModelFactory.newPolicyBuilder(policyId)
+                .forLabel("ADMIN")
+                .setSubject(defaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(pImport)))
+                .setImportsAliases(PoliciesModelFactory.newImportsAliases(Collections.singletonList(a)))
+                .build();
+    }
+
+    private void createTemplateThenImportingPolicy() {
+        putPolicy(templatePolicyId, templatePolicy).expectingHttpStatus(CREATED).fire();
+        putPolicy(importingPolicyId, importingPolicy).expectingHttpStatus(CREATED).fire();
+    }
+
+    private static Subject defaultSubject() {
+        return serviceEnv.getDefaultTestingContext().getOAuthClient().getDefaultSubject();
+    }
+
+    private static PutMatcher putImportsAliases(final CharSequence policyId, final ImportsAliases importsAliases) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAliases().toString();
+        return put(dittoUrl(TestConstants.API_V_2, path), importsAliases.toJsonString())
+                .withLogging(LOGGER, "ImportsAliases");
+    }
+
+    private static GetMatcher getImportsAliases(final CharSequence policyId) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAliases().toString();
+        return get(dittoUrl(TestConstants.API_V_2, path)).withLogging(LOGGER, "ImportsAliases");
+    }
+
+    private static DeleteMatcher deleteImportsAliases(final CharSequence policyId) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAliases().toString();
+        return delete(dittoUrl(TestConstants.API_V_2, path)).withLogging(LOGGER, "ImportsAliases");
+    }
+
+    private static PutMatcher putImportsAlias(final CharSequence policyId, final Label label,
+            final JsonObject aliasJson) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAlias(label).toString();
+        return put(dittoUrl(TestConstants.API_V_2, path), aliasJson.toString())
+                .withLogging(LOGGER, "ImportsAlias");
+    }
+
+    private static GetMatcher getImportsAlias(final CharSequence policyId, final Label label) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAlias(label).toString();
+        return get(dittoUrl(TestConstants.API_V_2, path)).withLogging(LOGGER, "ImportsAlias");
+    }
+
+    private static DeleteMatcher deleteImportsAlias(final CharSequence policyId, final Label label) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImportsAlias(label).toString();
+        return delete(dittoUrl(TestConstants.API_V_2, path)).withLogging(LOGGER, "ImportsAlias");
+    }
+
+    private static DeleteMatcher deletePolicyImport(final CharSequence policyId,
+            final CharSequence importedPolicyId) {
+        final String path = ResourcePathBuilder.forPolicy(policyId).policyImport(importedPolicyId).toString();
+        return delete(dittoUrl(TestConstants.API_V_2, path)).withLogging(LOGGER, "PolicyImport");
+    }
+
+}

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/PolicyImportsAliasesIT.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.ditto.base.model.common.HttpStatus;
-import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -331,7 +330,7 @@ public final class PolicyImportsAliasesIT extends IntegrationTest {
                         .build())
                 .set("resources", JsonObject.newBuilder()
                         .set("thing:/", JsonObject.newBuilder()
-                                .set("grant", JsonArray.of("READ"))
+                                .set("grant", JsonFactory.newArrayBuilder().add("READ").build())
                                 .set("revoke", JsonFactory.newArray())
                                 .build())
                         .build())

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/PolicyImportsAliasesWebSocketIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/PolicyImportsAliasesWebSocketIT.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +44,7 @@ import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.AllowedImportAddition;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectType;
 import org.eclipse.ditto.policies.model.Subjects;
@@ -167,7 +169,7 @@ public final class PolicyImportsAliasesWebSocketIT extends IntegrationTest {
 
         assertThat(response).isInstanceOf(RetrieveImportsAliasResponse.class);
         final RetrieveImportsAliasResponse retrieveResponse = (RetrieveImportsAliasResponse) response;
-        assertThat(retrieveResponse.getImportsAlias()).isEqualTo(alias);
+        assertThat(retrieveResponse.getEntity()).isEqualTo(alias.toJson());
     }
 
     @Test
@@ -191,7 +193,8 @@ public final class PolicyImportsAliasesWebSocketIT extends IntegrationTest {
         ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         assertThat(retrieveResponse).isInstanceOf(RetrieveImportsAliasResponse.class);
-        assertThat(((RetrieveImportsAliasResponse) retrieveResponse).getImportsAlias()).isEqualTo(modifiedAlias);
+        final RetrieveImportsAliasResponse verifyResponse = (RetrieveImportsAliasResponse) retrieveResponse;
+        assertThat(verifyResponse.getEntity()).isEqualTo(modifiedAlias.toJson());
     }
 
     @Test
@@ -306,10 +309,12 @@ public final class PolicyImportsAliasesWebSocketIT extends IntegrationTest {
                 .setSubject(testingContext.getOAuthClient().getDefaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor("operator-reactor", Set.of(AllowedImportAddition.SUBJECTS))
                 .forLabel("operator-turbine")
                 .setSubject(testingContext.getOAuthClient().getDefaultSubject())
                 .setGrantedPermissions(thingResource("/"), READ, WRITE)
                 .setImportable(ImportableType.EXPLICIT)
+                .setAllowedImportAdditionsFor("operator-turbine", Set.of(AllowedImportAddition.SUBJECTS))
                 .build();
 
         final Signal<?> createTemplateResponse = wsClient.send(

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/PolicyImportsAliasesWebSocketIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/PolicyImportsAliasesWebSocketIT.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.testing.system.things.ws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.policyResource;
+import static org.eclipse.ditto.policies.model.PoliciesResourceType.thingResource;
+import static org.eclipse.ditto.testing.common.TestConstants.API_V_2;
+import static org.eclipse.ditto.things.api.Permission.READ;
+import static org.eclipse.ditto.things.api.Permission.WRITE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.EntriesAdditions;
+import org.eclipse.ditto.policies.model.EntryAddition;
+import org.eclipse.ditto.policies.model.ImportsAlias;
+import org.eclipse.ditto.policies.model.ImportsAliases;
+import org.eclipse.ditto.policies.model.ImportsAliasTarget;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
+import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
+import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicyResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeleteImportsAlias;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeleteImportsAliasResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeleteImportsAliases;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeleteImportsAliasesResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicy;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyImportsAlias;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyImportsAliasResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyImportsAliases;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyImportsAliasesResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjects;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjectsResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveImportsAlias;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveImportsAliasResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveImportsAliases;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveImportsAliasesResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubjects;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubjectsResponse;
+import org.eclipse.ditto.testing.common.IntegrationTest;
+import org.eclipse.ditto.testing.common.ServiceEnvironment;
+import org.eclipse.ditto.testing.common.TestingContext;
+import org.eclipse.ditto.testing.common.config.TestConfig;
+import org.eclipse.ditto.testing.common.config.TestEnvironment;
+import org.eclipse.ditto.testing.common.ws.ThingsWebsocketClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * WebSocket / Ditto Protocol integration tests for policy import aliases — verifying that CRUD operations and
+ * subject fan-out work correctly through the WebSocket channel.
+ */
+public final class PolicyImportsAliasesWebSocketIT extends IntegrationTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PolicyImportsAliasesWebSocketIT.class);
+    private static final long TIMEOUT_SECONDS = 15;
+
+    private static final Label ALIAS_LABEL = Label.of("operator");
+    private static final Label TARGET_LABEL_1 = Label.of("operator-reactor");
+    private static final Label TARGET_LABEL_2 = Label.of("operator-turbine");
+
+    private ThingsWebsocketClient wsClient;
+    private TestingContext testingContext;
+
+    private PolicyId templatePolicyId;
+    private PolicyId importingPolicyId;
+    private ImportsAlias alias;
+    private ImportsAliases aliases;
+
+    @Before
+    public void setUp() {
+        if (TestConfig.getInstance().getTestEnvironment() == TestEnvironment.DEPLOYMENT) {
+            testingContext = serviceEnv.getDefaultTestingContext();
+        } else {
+            testingContext = TestingContext.withGeneratedMockClient(
+                    ServiceEnvironment.createSolutionWithRandomUsernameRandomNamespace(), TEST_CONFIG);
+        }
+
+        wsClient = newTestWebsocketClient(testingContext, new HashMap<>(), API_V_2);
+        wsClient.connect("PolicyImportsAliasesWS-" + UUID.randomUUID());
+
+        templatePolicyId = PolicyId.inNamespaceWithRandomName(
+                testingContext.getSolution().getDefaultNamespace());
+        importingPolicyId = PolicyId.inNamespaceWithRandomName(
+                testingContext.getSolution().getDefaultNamespace());
+
+        final List<ImportsAliasTarget> targets = Arrays.asList(
+                PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1),
+                PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_2)
+        );
+        alias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL, targets);
+        aliases = PoliciesModelFactory.newImportsAliases(Collections.singletonList(alias));
+    }
+
+    @After
+    public void tearDown() {
+        if (wsClient != null) {
+            try {
+                wsClient.send(DeletePolicy.of(importingPolicyId, headers())).toCompletableFuture()
+                        .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (final Exception e) {
+                LOGGER.debug("Cleanup of importing policy failed: {}", e.getMessage());
+            }
+            try {
+                wsClient.send(DeletePolicy.of(templatePolicyId, headers())).toCompletableFuture()
+                        .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (final Exception e) {
+                LOGGER.debug("Cleanup of template policy failed: {}", e.getMessage());
+            }
+            wsClient.disconnect();
+        }
+    }
+
+    // --- CRUD via WebSocket ---
+
+    @Test
+    public void createPolicyWithAliasesAndRetrieveViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        final Signal<?> response = wsClient.send(
+                RetrieveImportsAliases.of(importingPolicyId, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(response).isInstanceOf(RetrieveImportsAliasesResponse.class);
+        final RetrieveImportsAliasesResponse retrieveResponse = (RetrieveImportsAliasesResponse) response;
+        assertThat(retrieveResponse.getImportsAliases()).isEqualTo(aliases);
+    }
+
+    @Test
+    public void retrieveSingleImportsAliasViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        final Signal<?> response = wsClient.send(
+                RetrieveImportsAlias.of(importingPolicyId, ALIAS_LABEL, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(response).isInstanceOf(RetrieveImportsAliasResponse.class);
+        final RetrieveImportsAliasResponse retrieveResponse = (RetrieveImportsAliasResponse) response;
+        assertThat(retrieveResponse.getImportsAlias()).isEqualTo(alias);
+    }
+
+    @Test
+    public void modifySingleImportsAliasViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        // Modify alias to have only one target
+        final ImportsAlias modifiedAlias = PoliciesModelFactory.newImportsAlias(ALIAS_LABEL,
+                Collections.singletonList(
+                        PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1)));
+
+        final Signal<?> modifyResponse = wsClient.send(
+                ModifyImportsAlias.of(importingPolicyId, modifiedAlias, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(modifyResponse).isInstanceOf(ModifyImportsAliasResponse.class);
+
+        // Verify the modification
+        final Signal<?> retrieveResponse = wsClient.send(
+                RetrieveImportsAlias.of(importingPolicyId, ALIAS_LABEL, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(retrieveResponse).isInstanceOf(RetrieveImportsAliasResponse.class);
+        assertThat(((RetrieveImportsAliasResponse) retrieveResponse).getImportsAlias()).isEqualTo(modifiedAlias);
+    }
+
+    @Test
+    public void modifyAllImportsAliasesViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        // Replace all aliases with a new one
+        final Label newLabel = Label.of("inspector");
+        final ImportsAlias newAlias = PoliciesModelFactory.newImportsAlias(newLabel,
+                Collections.singletonList(
+                        PoliciesModelFactory.newImportsAliasTarget(templatePolicyId, TARGET_LABEL_1)));
+        final ImportsAliases newAliases = PoliciesModelFactory.newImportsAliases(Collections.singletonList(newAlias));
+
+        final Signal<?> modifyResponse = wsClient.send(
+                ModifyImportsAliases.of(importingPolicyId, newAliases, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(modifyResponse).isInstanceOf(ModifyImportsAliasesResponse.class);
+
+        // Verify
+        final Signal<?> retrieveResponse = wsClient.send(
+                RetrieveImportsAliases.of(importingPolicyId, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(retrieveResponse).isInstanceOf(RetrieveImportsAliasesResponse.class);
+        assertThat(((RetrieveImportsAliasesResponse) retrieveResponse).getImportsAliases()).isEqualTo(newAliases);
+    }
+
+    @Test
+    public void deleteSingleImportsAliasViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        final Signal<?> deleteResponse = wsClient.send(
+                DeleteImportsAlias.of(importingPolicyId, ALIAS_LABEL, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(deleteResponse).isInstanceOf(DeleteImportsAliasResponse.class);
+
+        // Verify deletion — retrieve should return empty aliases
+        final Signal<?> retrieveResponse = wsClient.send(
+                RetrieveImportsAliases.of(importingPolicyId, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(retrieveResponse).isInstanceOf(RetrieveImportsAliasesResponse.class);
+        assertThat(((RetrieveImportsAliasesResponse) retrieveResponse).getImportsAliases().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void deleteAllImportsAliasesViaWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        final Signal<?> deleteResponse = wsClient.send(
+                DeleteImportsAliases.of(importingPolicyId, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(deleteResponse).isInstanceOf(DeleteImportsAliasesResponse.class);
+
+        // Verify
+        final Signal<?> retrieveResponse = wsClient.send(
+                RetrieveImportsAliases.of(importingPolicyId, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(retrieveResponse).isInstanceOf(RetrieveImportsAliasesResponse.class);
+        assertThat(((RetrieveImportsAliasesResponse) retrieveResponse).getImportsAliases().isEmpty()).isTrue();
+    }
+
+    // --- Subject fan-out via WebSocket ---
+
+    @Test
+    public void modifySubjectsViaAliasLabelFansOutThroughWebSocket() throws Exception {
+        createTemplateThenImportingPolicy();
+
+        final Subject newSubject = Subject.newInstance(
+                serviceEnv.getTestingContext2().getOAuthClient().getDefaultSubject().getId(),
+                SubjectType.GENERATED);
+        final Subjects subjects = Subjects.newInstance(newSubject);
+
+        // ModifySubjects using the alias label → should fan out to all targets
+        final Signal<?> modifyResponse = wsClient.send(
+                ModifySubjects.of(importingPolicyId, ALIAS_LABEL, subjects, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(modifyResponse).isInstanceOf(ModifySubjectsResponse.class);
+
+        // Retrieve subjects through alias — should return subjects from first target
+        final Signal<?> retrieveResponse = wsClient.send(
+                RetrieveSubjects.of(importingPolicyId, ALIAS_LABEL, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertThat(retrieveResponse).isInstanceOf(RetrieveSubjectsResponse.class);
+        final RetrieveSubjectsResponse subjectsResponse = (RetrieveSubjectsResponse) retrieveResponse;
+        assertThat(subjectsResponse.getSubjects().getSubject(newSubject.getId())).isPresent();
+    }
+
+    // --- Helpers ---
+
+    private DittoHeaders headers() {
+        return DittoHeaders.newBuilder()
+                .schemaVersion(JsonSchemaVersion.V_2)
+                .randomCorrelationId()
+                .build();
+    }
+
+    private void createTemplateThenImportingPolicy() throws Exception {
+        // Create template policy via REST (simpler setup)
+        final Policy templatePolicy = PoliciesModelFactory.newPolicyBuilder(templatePolicyId)
+                .forLabel("ADMIN")
+                .setSubject(testingContext.getOAuthClient().getDefaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel("operator-reactor")
+                .setSubject(testingContext.getOAuthClient().getDefaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .forLabel("operator-turbine")
+                .setSubject(testingContext.getOAuthClient().getDefaultSubject())
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setImportable(ImportableType.EXPLICIT)
+                .build();
+
+        final Signal<?> createTemplateResponse = wsClient.send(
+                CreatePolicy.of(templatePolicy, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(createTemplateResponse).isInstanceOf(CreatePolicyResponse.class);
+
+        // Build import with entries additions
+        final EntryAddition addition1 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_1, null, null);
+        final EntryAddition addition2 = PoliciesModelFactory.newEntryAddition(TARGET_LABEL_2, null, null);
+        final EntriesAdditions entriesAdditions =
+                PoliciesModelFactory.newEntriesAdditions(Arrays.asList(addition1, addition2));
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Arrays.asList(TARGET_LABEL_1, TARGET_LABEL_2), entriesAdditions);
+        final PolicyImport policyImport = PoliciesModelFactory.newPolicyImport(templatePolicyId, effectedImports);
+
+        // Create importing policy with alias via WebSocket
+        final Policy importingPolicy = PoliciesModelFactory.newPolicyBuilder(importingPolicyId)
+                .forLabel("ADMIN")
+                .setSubject(testingContext.getOAuthClient().getDefaultSubject())
+                .setGrantedPermissions(policyResource("/"), READ, WRITE)
+                .setGrantedPermissions(thingResource("/"), READ, WRITE)
+                .setPolicyImports(PoliciesModelFactory.newPolicyImports(Collections.singletonList(policyImport)))
+                .setImportsAliases(aliases)
+                .build();
+
+        final Signal<?> createImportingResponse = wsClient.send(
+                CreatePolicy.of(importingPolicy, headers())
+        ).toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(createImportingResponse).isInstanceOf(CreatePolicyResponse.class);
+    }
+
+}


### PR DESCRIPTION
Adding tests for eclipse-ditto/ditto#2402

Add REST, WebSocket, and search integration tests for the new policy import aliases feature. Tests cover CRUD operations on /importsAliases endpoints, subject fan-out through alias labels, policy enforcement (subject added via alias gains/loses access to things), search index consistency, and conflict/protection scenarios.