### PR TITLE
Fix policy subjects and ignore unfixed bugs tests for 3.8.12

### DIFF
--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/rest/ThingsIT.java
@@ -36,7 +36,6 @@ import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectIssuer;
 import org.eclipse.ditto.policies.model.Subjects;
-import org.eclipse.ditto.testing.common.ThingsSubjectIssuer;
 import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.testing.common.HttpHeader;
 import org.eclipse.ditto.testing.common.HttpParameter;
@@ -788,16 +787,14 @@ public final class ThingsIT extends IntegrationTest {
     public void getThingWithPartialAccessReturnsOnlyAccessiblePaths() {
         final ThingId thingId = ThingId.of(idGenerator().withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = serviceEnv.getDefaultTestingContext().getOAuthClient().getClientId();
-        final String clientId2 = serviceEnv.getTestingContext2().getOAuthClient().getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), Permission.WRITE, Permission.READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permission.WRITE, Permission.READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/public", "READ")
                 .setGrantedPermissions("thing", "/attributes/shared", "READ")
                 .setGrantedPermissions("thing", "/features/temperature/properties/value", "READ")

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/sse/ThingsServerSentEventIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/sse/ThingsServerSentEventIT.java
@@ -18,6 +18,7 @@ import static org.eclipse.ditto.base.model.assertions.DittoBaseAssertions.assert
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +50,6 @@ import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.testing.common.ThingsSubjectIssuer;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
@@ -57,6 +57,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 
 /**
@@ -675,16 +676,14 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
     public void partialAccessEventsAreFilteredViaSse() {
         final ThingId thingId = ThingId.of(idGenerator(interestingNamespace).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = serviceEnv.getDefaultTestingContext().getOAuthClient().getClientId();
-        final String clientId2 = serviceEnv.getTestingContext2().getOAuthClient().getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), Permission.WRITE, Permission.READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permission.WRITE, Permission.READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/public", "READ")
                 .setGrantedPermissions("thing", "/attributes/shared", "READ")
                 .setGrantedPermissions("thing", "/features/temperature/properties/value", "READ")
@@ -778,6 +777,7 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
 
     @Test
     @Category(Acceptance.class)
+    @Ignore("Fixed with https://github.com/eclipse-ditto/ditto/pull/2287, but not included in Ditto 3.8 at all")
     public void partialAccessEventsFilteredForRevokedPathsStrictMatchingViaSse() {
         final String ATTR_TYPE = "type";
         final String ATTR_HIDDEN = "hidden";
@@ -802,23 +802,21 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
 
         final ThingId thingId = ThingId.of(idGenerator(interestingNamespace).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = serviceEnv.getDefaultTestingContext().getOAuthClient().getClientId();
-        final String clientId2 = serviceEnv.getTestingContext2().getOAuthClient().getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), Permission.WRITE, Permission.READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permission.WRITE, Permission.READ)
                 .forLabel("partial1")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_TYPE, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_SOME, "READ")
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/" + ATTR_HIDDEN), Permission.READ)
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/" + ATTR_COMPLEX_SECRET), Permission.READ)
                 .forLabel("partial2")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_OTHER + "/properties/properties/" + PROP_PUBLIC, "READ")
@@ -993,6 +991,7 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
 
     @Test
     @Category(Acceptance.class)
+    @Ignore("Fixed with https://github.com/eclipse-ditto/ditto/pull/2287, but not included in Ditto 3.8 at all")
     public void partialAccessComprehensiveTestAllScenariosViaSse() {
         final String ATTR_TYPE = "type";
         final String ATTR_HIDDEN = "hidden";
@@ -1024,16 +1023,14 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
 
         final ThingId thingId = ThingId.of(idGenerator(interestingNamespace).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = serviceEnv.getDefaultTestingContext().getOAuthClient().getClientId();
-        final String clientId2 = serviceEnv.getTestingContext2().getOAuthClient().getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), Permission.WRITE, Permission.READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permission.WRITE, Permission.READ)
                 .forLabel("partial1")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getDefaultTestingContext().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_TYPE, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_SOME, "READ")
@@ -1045,7 +1042,7 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/features/" + FEATURE_OTHER), Permission.READ)
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/features/" + FEATURE_SHARED + "/properties/" + PROP_SECRET), Permission.READ)
                 .forLabel("partial2")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, org.eclipse.ditto.policies.model.SubjectType.GENERATED)
+                .setSubject(serviceEnv.getTestingContext2().getOAuthClient().getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_OTHER, "READ")
@@ -1247,7 +1244,7 @@ public final class ThingsServerSentEventIT extends IntegrationTest {
                         return null;
                     }
                 })
-                .filter(jsonValue -> jsonValue != null)
+                .filter(Objects::nonNull)
                 .map(JsonValue::asObject)
                 .forEach(payload -> {
                     assertThat(payload.getValue(JsonPointer.of("/attributes/" + ATTR_HIDDEN))).isEmpty();

--- a/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/WebsocketIT.java
+++ b/system/src/test/java/org/eclipse/ditto/testing/system/things/ws/WebsocketIT.java
@@ -98,7 +98,6 @@ import org.eclipse.ditto.testing.common.IntegrationTest;
 import org.eclipse.ditto.testing.common.ServiceEnvironment;
 import org.eclipse.ditto.testing.common.Solution;
 import org.eclipse.ditto.testing.common.TestingContext;
-import org.eclipse.ditto.testing.common.ThingsSubjectIssuer;
 import org.eclipse.ditto.testing.common.categories.Acceptance;
 import org.eclipse.ditto.testing.common.client.BasicAuth;
 import org.eclipse.ditto.testing.common.client.oauth.AuthClient;
@@ -141,6 +140,7 @@ import org.eclipse.ditto.things.model.signals.events.ThingMerged;
 import org.eclipse.ditto.things.model.signals.events.ThingModified;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -152,7 +152,7 @@ import org.slf4j.LoggerFactory;
 public final class WebsocketIT extends IntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketIT.class);
-    private static final long LATCH_TIMEOUT_SECONDS = 30;
+    private static final long LATCH_TIMEOUT_SECONDS = 10;
     private static final AtomicInteger ACK_COUNTER = new AtomicInteger(0);
     private static final String THING_DEFINITION_URL = "https://eclipse-ditto.github.io/ditto-examples/wot/models/dimmable-colored-lamp-1.0.0.tm.jsonld";
 
@@ -488,10 +488,9 @@ public final class WebsocketIT extends IntegrationTest {
     private Policy prepareSpecialPolicyToCopy() {
         final PolicyId originalPolicyId = PolicyId.of(
                 idGenerator(testingContext1.getSolution().getDefaultNamespace()).withPrefixedRandomName("policyToCopy"));
-        final String clientId = testingContext1.getOAuthClient().getClientId();
         return PoliciesModelFactory.newPolicyBuilder(originalPolicyId)
                 .forLabel("specialCopiedLabel")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(testingContext1.getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .build();
@@ -656,21 +655,15 @@ public final class WebsocketIT extends IntegrationTest {
         //  - that the group1 ("All users group") user1 belongs to may not read the "secret" feature
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
 
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
-
         final PolicyId policyId = PolicyId.of(thingId);
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("granted")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1,
-                        SubjectType.newInstance("user1isBoss"))
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2,
-                        SubjectType.newInstance("user2isBoss"))
+                .setSubject(user1OAuthClient.getSubject())
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("revoked")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1,
-                        SubjectType.newInstance("group1mayNotReadSecretFeature"))
+                .setSubject(user1OAuthClient.getSubject())
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/features/secret"), READ)
                 .build();
 
@@ -1563,16 +1556,14 @@ public final class WebsocketIT extends IntegrationTest {
     public void partialAccessEventsAreFilteredForRestrictedSubjects() throws Exception {
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/public", "READ")
                 .setGrantedPermissions("thing", "/attributes/shared", "READ")
                 .setGrantedPermissions("thing", "/features/temperature/properties/value", "READ")
@@ -1643,17 +1634,14 @@ public final class WebsocketIT extends IntegrationTest {
         // GIVEN: A user with READ access only to attributes/something/special and features/public
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        // Use a different OAuth client for the owner to avoid permission merging with partial access subjects
-        final String ownerClientId = getOwnerClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, ownerClientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(serviceEnv.getTestingContext4().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setGrantedPermissions("thing", "/features/public", "READ")
                 .build();
@@ -1780,21 +1768,19 @@ public final class WebsocketIT extends IntegrationTest {
 
     @Test
     @Category(Acceptance.class)
+    @Ignore("Fixed with https://github.com/eclipse-ditto/ditto/pull/2287, but not included in Ditto 3.8 at all")
     public void partialAccessEventsFilteredForMergeThingUpdates() throws Exception {
         // GIVEN: A user with READ access only to attributes/something/special and features/public
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        // Use a different OAuth client for the owner to avoid permission merging
-        final String ownerClientId = getOwnerClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, ownerClientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(serviceEnv.getTestingContext4().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setGrantedPermissions("thing", "/features/public", "READ")
                 .build();
@@ -1875,17 +1861,14 @@ public final class WebsocketIT extends IntegrationTest {
         // GIVEN: A user with READ access only to attributes/something/special and features/public
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        // Use a different OAuth client for the owner to avoid permission merging with partial access subjects
-        final String ownerClientId = getOwnerClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, ownerClientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(serviceEnv.getTestingContext4().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setGrantedPermissions("thing", "/features/public", "READ")
                 .build();
@@ -2025,16 +2008,14 @@ public final class WebsocketIT extends IntegrationTest {
         // GIVEN: A user with READ access only to attributes/something/special and features/public
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setGrantedPermissions("thing", "/features/public", "READ")
                 .build();
@@ -2128,16 +2109,14 @@ public final class WebsocketIT extends IntegrationTest {
         // GIVEN: A user with READ access to attributes/something/special but with revoke on attributes/something/special/hidden
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/something/special/hidden"), READ)
                 .build();
@@ -2239,17 +2218,14 @@ public final class WebsocketIT extends IntegrationTest {
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
         // Use a different OAuth client for the owner to avoid permission merging with partial access subjects
-        final String ownerClientId = getOwnerClientId();
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, ownerClientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(serviceEnv.getTestingContext4().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("user1")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 // Don't grant general /attributes access - only specific paths
                 // This ensures User1 is included in partial access subjects
                 .setGrantedPermissions("thing", "/attributes/type", "READ")
@@ -2259,7 +2235,7 @@ public final class WebsocketIT extends IntegrationTest {
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/hidden"), READ)
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/complex/secret"), READ)
                 .forLabel("user2")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/complex", "READ")
                 .setGrantedPermissions("thing", "/attributes/complex/some", "READ")
                 // Note: The Thing structure has double "properties" nesting: properties.properties.public
@@ -2713,16 +2689,14 @@ public final class WebsocketIT extends IntegrationTest {
         // 5. Updating attributes/something/special (specific path)
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/something/special", "READ")
                 .setGrantedPermissions("thing", "/features/public", "READ")
                 .build();
@@ -2989,17 +2963,14 @@ public final class WebsocketIT extends IntegrationTest {
 
         final ThingId thingId = ThingId.of(idGenerator(testingContext1.getSolution().getDefaultNamespace()).withRandomName());
         final PolicyId policyId = PolicyId.of(thingId);
-        final String ownerClientId = getOwnerClientId();
-        final String clientId1 = user1OAuthClient.getClientId();
-        final String clientId2 = user2OAuthClient.getClientId();
 
         final Policy policy = PoliciesModelFactory.newPolicyBuilder(policyId)
                 .forLabel("owner")
-                .setSubject(ThingsSubjectIssuer.DITTO, ownerClientId, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(serviceEnv.getTestingContext4().getOAuthClient().getSubject())
                 .setGrantedPermissions(PoliciesResourceType.policyResource("/"), WRITE, READ)
                 .setGrantedPermissions(PoliciesResourceType.thingResource("/"), WRITE, READ)
                 .forLabel("partial1")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId1, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user1OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_TYPE, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_SOME, "READ")
@@ -3011,7 +2982,7 @@ public final class WebsocketIT extends IntegrationTest {
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/features/" + FEATURE_OTHER), READ)
                 .setRevokedPermissions(PoliciesResourceType.thingResource("/features/" + FEATURE_SHARED + "/properties/" + PROP_SECRET), READ)
                 .forLabel("partial2")
-                .setSubject(ThingsSubjectIssuer.DITTO, clientId2, ARBITRARY_SUBJECT_TYPE)
+                .setSubject(user2OAuthClient.getSubject())
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX, "READ")
                 .setGrantedPermissions("thing", "/attributes/" + ATTR_COMPLEX_SOME, "READ")
                 .setGrantedPermissions("thing", "/features/" + FEATURE_OTHER, "READ")


### PR DESCRIPTION
What's changed:
- Policy subjects of recently added tests are fixed in order to work on customer environments.
- 3 failing tests related to partial access events are ignored as the fixes they test are not included in Ditto 3.8 at all.